### PR TITLE
fix(macapp): harden gh auth gate with --active (#50)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -327,3 +327,32 @@ collides with a bundled family.
 **Depends on:** the #36 families model shipping first (done).
 
 **Priority:** P3 (bundled families cover the common case; this is for users with custom schemes).
+
+## Harden `gh` auth detection — robust gate (macapp) — #50 follow-up
+
+**What:** Replace the exit-code-based global GitHub-auth gate with a more robust design — either
+parse `gh auth status --json hosts` (always exits 0; classify the active account's `state` in
+Swift) or de-gate so the per-workroom PR/CI probes self-classify their own auth failures (they
+already return `.absent` on `!r.ok`) and the global `githubCLIStatus` becomes advisory.
+
+**Current state:** #50 was fixed by adding `--active` to `gh auth status`
+(`Core/WorkroomStatusResolver.swift` `resolveGitHubCLI`). That is correct for current gh but leans
+on `gh`'s exit-code behavior and carries a **gh ≥ 2.57.0** floor (where `--active` was added).
+
+**Why:** removes the dependency on `gh`'s exit-code quirk and the version floor, and closes the
+residual multi-host case the `--active` fix leaves open — the global probe runs host-agnostic in
+`NSTemporaryDirectory()`, so a broken *active* account on an unrelated host (e.g. a GHE server the
+user still has configured) still trips a false "not signed in". `--json hosts` lets the check be
+host-aware without pinning `--hostname` (which would break GitHub Enterprise users).
+
+**How to start:** prototype `gh auth status --json hosts` parsing in `classifyGitHubCLI` (note the
+`--json` field set + `state`/`active` schema also has a gh version floor — confirm it). Or, for the
+de-gate route, relax `guard self.githubCLIStatus == .available else { return }`
+(`Core/AppStore+WorkroomStatus.swift:74`, `:121`) — but weigh the deliberate "don't spawn a `gh`
+per workroom when logged out" optimization it currently buys (`:70-73`), and rework the
+`PullRequestPanel` "not signed in" warning, which is driven by the global status.
+
+**Depends on:** nothing — pure follow-up to the #50 `--active` fix.
+
+**Priority:** P3 (the `--active` fix covers the reported bug and current gh; revisit only if
+multi-host or old-gh false-negatives get reported).

--- a/macapp/README.md
+++ b/macapp/README.md
@@ -16,6 +16,10 @@ binary** and shelling out over its `--json` contract — no cgo, no duplicated l
 - Go (to build the embedded helper) — must be on `PATH`, or edit `Scripts/build-helper.sh`
 - [XcodeGen](https://github.com/yonaskolb/XcodeGen): `brew install xcodegen`
 
+> **Runtime (not build):** the inspector's pull-request / CI section shells out to the GitHub CLI.
+> It needs **`gh` ≥ 2.57.0** on `PATH` and an authenticated active account — the auth probe uses
+> `gh auth status --active`, and `--active` landed in gh 2.57.0 (issue #50).
+
 ## Build & run
 
 ```bash

--- a/macapp/WorkroomApp/Core/WorkroomStatusResolver.swift
+++ b/macapp/WorkroomApp/Core/WorkroomStatusResolver.swift
@@ -226,11 +226,17 @@ struct WorkroomStatusResolver: Sendable {
   }
 
   /// Probe whether `gh` is installed and authenticated (machine-global, not per-workroom). Runs
-  /// `gh auth status` in a neutral dir; a network/keyring blip (timeout) reports `available` so a
-  /// flaky connection doesn't raise a false "not signed in" warning.
+  /// `gh auth status --active` in a neutral dir; a network/keyring blip (timeout) reports
+  /// `available` so a flaky connection doesn't raise a false "not signed in" warning.
+  ///
+  /// `--active` (gh ≥ 2.57.0) scopes the check to the *active* account on each host — the one
+  /// `gh pr list` / `gh run list` actually use. Without it, plain `gh auth status` exits non-zero
+  /// when *any* account on *any* host has an issue, so a single broken secondary / GitHub-App
+  /// account would flip the whole app to "not signed in" and gate off the CI/PR sweep even though
+  /// the active account works fine (issue #50).
   func resolveGitHubCLI() async -> GitHubCLIStatus {
     let r = await runner.run(
-      "gh", ["auth", "status"], in: NSTemporaryDirectory(), timeout: ciTimeout)
+      "gh", ["auth", "status", "--active"], in: NSTemporaryDirectory(), timeout: ciTimeout)
     return Self.classifyGitHubCLI(r)
   }
 
@@ -239,7 +245,9 @@ struct WorkroomStatusResolver: Sendable {
   static func classifyGitHubCLI(_ r: CommandResult) -> GitHubCLIStatus {
     if r.exitCode == CommandResult.commandNotFound { return .notInstalled }
     if r.timedOut { return .available }  // network/keyring blip — don't cry wolf
-    return r.ok ? .available : .notAuthenticated  // gh auth status fails only when not logged in
+    // With `--active`, a non-zero exit means the *active* account specifically isn't authenticated.
+    // (Plain `gh auth status` would also fail on a broken *secondary* account — the cause of #50.)
+    return r.ok ? .available : .notAuthenticated
   }
 
   struct GitParse: Equatable {

--- a/macapp/WorkroomAppTests/WorkroomStatusResolverTests.swift
+++ b/macapp/WorkroomAppTests/WorkroomStatusResolverTests.swift
@@ -732,4 +732,20 @@ final class WorkroomStatusResolverTests: XCTestCase {
     let status = await r.resolveGitHubCLI()
     XCTAssertEqual(status, .notInstalled)
   }
+
+  /// Regression lock for issue #50. The auth probe MUST pass `--active`: plain `gh auth status`
+  /// exits non-zero when *any* account on *any* host has an issue, so a broken secondary /
+  /// GitHub-App account would flip the whole app to "not signed in". `--active` scopes the check to
+  /// the active account (the one the PR/CI probes use). Asserting the flag directly stops a future
+  /// edit from silently dropping it — the other `resolveGitHubCLI` tests match only `"auth"` and
+  /// would stay green without it.
+  func testResolveGitHubCLIProbesActiveAccountOnly() async {
+    let runner = RecordingStatusRunner { _, _ in ok("Logged in") }
+    let r = WorkroomStatusResolver(runner: runner)
+    let status = await r.resolveGitHubCLI()
+    XCTAssertEqual(status, .available)
+    let authCall = runner.calls.first { $0.exe == "gh" && $0.args.contains("auth") }
+    XCTAssertNotNil(authCall, "resolveGitHubCLI should invoke `gh auth status`")
+    XCTAssertEqual(authCall?.args, ["auth", "status", "--active"])
+  }
 }


### PR DESCRIPTION
## What

The macOS inspector's global GitHub-auth gate ran plain `gh auth status`. That command exits **non-zero when _any_ account on _any_ host** has an issue — so a single broken secondary / GitHub-App account flipped the whole app to "not signed in" and gated off the per-workroom PR/CI sweep, even when the active account worked fine (#50).

## Fix

- Pass `--active` (gh ≥ 2.57.0) so the probe is scoped to the **active account on each host** — the one `gh pr list` / `gh run list` actually use.
- `WorkroomStatusResolver.resolveGitHubCLI` + `classifyGitHubCLI` doc comments updated to explain the flag and the failure mode it closes.

## Verification

- Added `testResolveGitHubCLIProbesActiveAccountOnly` — a regression lock asserting the exact args `["auth", "status", "--active"]`. The other resolver tests match only `"auth"` and would stay green if the flag were dropped, so this asserts it directly.
- `WorkroomStatusResolverTests`: 74 tests pass.
- `swift-format lint --strict` clean on touched files.

## Notes

- Documents the **gh ≥ 2.57.0** floor in `macapp/README.md` (where `--active` landed).
- Files a P3 follow-up in `TODOS.md` to either de-gate the global probe or move to `gh auth status --json hosts` parsing (host-aware, no exit-code dependency, no version floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)