### PR TITLE
feat(macapp): open a terminal in new workrooms setting

### DIFF
--- a/macapp/WorkroomApp/Core/AppStore.swift
+++ b/macapp/WorkroomApp/Core/AppStore.swift
@@ -886,6 +886,18 @@ final class AppStore: ObservableObject {
     runStates[targetID] = .armed
   }
 
+  /// Workrooms just created with the "open a terminal in new workrooms" setting on
+  /// (`Defaults[.openTerminalOnCreate]`), pending an initial shell on first pane mount. A one-shot
+  /// create-time marker, like an `.armed` run-state: consulted once at create and consumed by
+  /// `ensureInitialTerminal`, so selecting an *existing* workroom never spawns a terminal (issue #23).
+  private var pendingOpenTerminal: Set<TerminalTarget.ID> = []
+
+  /// Arm a just-created workroom to open a shell terminal once its pane mounts (post-setup), per the
+  /// `openTerminalOnCreate` setting. Called from `createWorkroom`, mirroring `armAutoRun`.
+  func armOpenTerminal(forWorkroom targetID: TerminalTarget.ID) {
+    pendingOpenTerminal.insert(targetID)
+  }
+
   /// Run an armed auto-run command as a target's first terminal when its pane first appears (called by
   /// the terminals view). Only acts when an auto-run was armed for this just-created workroom (issue
   /// #7) — the run command becomes the first tab instead of a default shell. Because the pane only
@@ -894,16 +906,35 @@ final class AppStore: ObservableObject {
   /// terminal (issue #23) — the user opens one with ⌘T. Falls back to a normal tab if the armed
   /// command can't start (e.g. config cleared between arming and mount).
   func ensureInitialTerminal(for target: TerminalTarget) {
-    // Auto-run (issue #7): when a workroom was just *created* with an auto-run command, start it as the
-    // first tab on first mount (post-setup). Selecting a workroom otherwise does NOT auto-create a
-    // terminal — the user opens one with ⌘T (or the empty state's "New Terminal" button). So a
-    // selected-but-untouched workroom shows the empty state and gets no tab until a terminal exists.
-    guard case .armed = runStates[target.id] else { return }
-    // Consume the armed intent, then let startRunCommand (re-)derive the state: it becomes `.running`
-    // as the workroom's first tab, or a no-op if the config was cleared between arming and mount.
-    runStates[target.id] = nil
-    startRunCommand(for: target)
-    if terminals.tabCount(forTargetID: target.id) == 0 { terminals.ensureTab(for: target) }
+    // Both intents are one-shot create-time markers (issue #7 / `openTerminalOnCreate`). Selecting a
+    // workroom otherwise does NOT auto-create a terminal — the user opens one with ⌘T (or the empty
+    // state's "New Terminal" button) — so an existing, un-marked workroom shows the empty state and
+    // gets no tab here. Consume both up front so a later re-mount (navigating away and back) can't
+    // re-fire either.
+    let isArmed: Bool
+    if case .armed = runStates[target.id] { isArmed = true } else { isArmed = false }
+    let opensShell = pendingOpenTerminal.remove(target.id) != nil
+    guard isArmed || opensShell else { return }
+
+    // Auto-run: start the project's command as the workroom's first tab (post-setup). Consume the
+    // armed intent first, then let startRunCommand (re-)derive the state: it becomes `.running` as
+    // tab #1, or a no-op if the config was cleared between arming and mount.
+    if isArmed {
+      runStates[target.id] = nil
+      startRunCommand(for: target)
+    }
+
+    // "Open a terminal in new workrooms": open a plain shell. Independent of auto-run — when both
+    // fire, the run command stays tab #1 and focused (the prominent thing) and this shell is tab #2,
+    // available behind it. `addTab` focuses the new shell, so re-focus the run tab afterwards.
+    if opensShell {
+      terminals.addTab(for: target)
+      if isArmed, let runTab = runStates[target.id]?.tab { terminals.focus(runTab, for: target) }
+    }
+
+    // An armed run that couldn't start (config cleared after arming) still needs a usable terminal;
+    // open one unless the shell above already covered it.
+    if isArmed, terminals.tabCount(forTargetID: target.id) == 0 { terminals.ensureTab(for: target) }
   }
 
   // MARK: Loading
@@ -1115,10 +1146,16 @@ final class AppStore: ObservableObject {
               // when that terminal view first mounts: immediately for a no-setup workroom, or only
               // AFTER the user dismisses the blocking setup dialog (the terminal is withheld behind
               // it until then) — so the command runs post-setup, as intended.
+              let workroomID = TerminalTarget.workroomID(project: project.path, name: name)
               let cfg = self.runConfig(forProject: project.path)
               if cfg.autoRun, cfg.hasCommand {
-                self.armAutoRun(
-                  forWorkroom: TerminalTarget.workroomID(project: project.path, name: name))
+                self.armAutoRun(forWorkroom: workroomID)
+              }
+              // Open-a-terminal-on-create setting: arm a plain shell for first mount, independent of
+              // auto-run (fires alongside it — run command tab #1, shell tab #2). Like auto-run, this
+              // fires post-setup because the pane is withheld behind the blocking setup dialog.
+              if Defaults[.openTerminalOnCreate] {
+                self.armOpenTerminal(forWorkroom: workroomID)
               }
               await self.mountSetupLog(session, workroom: name, project: project, blocking: setup)
             }
@@ -1202,6 +1239,8 @@ final class AppStore: ObservableObject {
       // `reap` only fires `onTabsRemoved` (which clears run state) when tabs existed; a workroom armed
       // for auto-run but deleted before its pane mounted has none, so clear directly too (issue #7).
       self.runStates[targetID] = nil
+      // Same for a created-then-deleted-before-mount workroom marked to open a shell on create.
+      self.pendingOpenTerminal.remove(targetID)
       self.clearRunPidFile(for: targetID)
       self.logs[targetID] = nil
       // Drop the gone workroom's notifications and pull any banners it already delivered.

--- a/macapp/WorkroomApp/Core/DefaultsKeys.swift
+++ b/macapp/WorkroomApp/Core/DefaultsKeys.swift
@@ -42,6 +42,13 @@ extension Defaults.Keys {
   /// Confirm before closing a terminal (closing kills its shell and any running process, no undo).
   static let confirmOnCloseTerminal = Key<Bool>("confirmOnCloseTerminal", default: true)
 
+  /// Open a fresh shell terminal in a newly created workroom, once any setup script has run and its
+  /// dialog is dismissed. Off by default, so the existing behaviour is unchanged (a created workroom
+  /// shows the empty state unless a run command auto-runs). Consulted once at create time; the run
+  /// command's auto-run is independent — when both fire the run command is tab #1 and this shell is
+  /// tab #2 (see `AppStore.ensureInitialTerminal`).
+  static let openTerminalOnCreate = Key<Bool>("openTerminalOnWorkroomCreate", default: false)
+
   /// Whether the global ⌘§ show/hide hotkey is registered (issue #13).
   static let globalHotkey = Key<Bool>("globalHotkeyEnabled", default: true)
 

--- a/macapp/WorkroomApp/Views/SettingsView.swift
+++ b/macapp/WorkroomApp/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
   @Default(.copyOnSelect) private var copyOnSelect
   @Default(.confirmOnQuit) private var confirmOnQuit
   @Default(.confirmOnCloseTerminal) private var confirmOnCloseTerminal
+  @Default(.openTerminalOnCreate) private var openTerminalOnCreate
   @Default(.globalHotkey) private var globalHotkey
   @Default(.showMenuBarItem) private var showMenuBarItem
   // Bundle id of the editor for ⌘-clicked file paths; "" = the file's default app.
@@ -50,6 +51,8 @@ struct SettingsView: View {
       Toggle("Confirm before quitting", isOn: $confirmOnQuit)
 
       Toggle("Confirm before closing a terminal", isOn: $confirmOnCloseTerminal)
+
+      Toggle("Open a terminal in new workrooms", isOn: $openTerminalOnCreate)
 
       Toggle("Global show/hide hotkey (⌘§)", isOn: $globalHotkey)
 

--- a/macapp/WorkroomAppTests/RunCommandTests.swift
+++ b/macapp/WorkroomAppTests/RunCommandTests.swift
@@ -270,6 +270,49 @@ final class RunCommandTests: XCTestCase {
     XCTAssertEqual(store.terminals.tabCount(forTargetID: t.id), 0, "no auto-spawned terminal")
   }
 
+  func testOpenTerminalOnCreateOpensShellWithoutAutoRun() {
+    let store = makeStore([project("/a", workrooms: ["main"])])
+    let t = target(store, "/a", "main")
+
+    // Setting on (armed at create), no run command auto-run → first mount opens a single plain shell,
+    // no run tab. This is the "open a terminal in new workrooms" setting standing alone.
+    store.armOpenTerminal(forWorkroom: t.id)
+    store.ensureInitialTerminal(for: t)
+
+    XCTAssertNil(store.runTabID(for: t.id), "no run command → no run tab")
+    XCTAssertFalse(store.isRunCommandRunning(for: t.id))
+    XCTAssertEqual(store.terminals.tabCount(forTargetID: t.id), 1, "one shell terminal opened")
+  }
+
+  func testOpenTerminalOnCreateAlongsideAutoRunOpensBothRunTabFocused() {
+    let store = makeStore([project("/a", workrooms: ["main"])])
+    store.setRunConfig(RunConfig(command: "echo hi", autoRun: true), forProject: "/a")
+    let t = target(store, "/a", "main")
+
+    // Both armed at create: auto-run becomes tab #1 (focused, prominent), the setting's shell is
+    // tab #2 (available behind it). The run command runs and the run tab stays focused.
+    store.armAutoRun(forWorkroom: t.id)
+    store.armOpenTerminal(forWorkroom: t.id)
+    store.ensureInitialTerminal(for: t)
+
+    XCTAssertTrue(store.isRunCommandRunning(for: t.id))
+    XCTAssertEqual(store.terminals.tabCount(forTargetID: t.id), 2, "run tab + shell tab")
+    XCTAssertEqual(
+      store.terminals.activeTab(for: t)?.id, store.runTabID(for: t.id),
+      "the run command, not the extra shell, stays focused")
+  }
+
+  func testOpenTerminalMarkerIsOneShot() {
+    let store = makeStore([project("/a", workrooms: ["main"])])
+    let t = target(store, "/a", "main")
+
+    store.armOpenTerminal(forWorkroom: t.id)
+    store.ensureInitialTerminal(for: t)
+    store.ensureInitialTerminal(for: t)  // a re-mount (navigate away and back) must not re-open
+
+    XCTAssertEqual(store.terminals.tabCount(forTargetID: t.id), 1, "no duplicate shell on re-mount")
+  }
+
   func testToggleStartsWhenNotRunning() {
     let store = makeStore([project("/a", workrooms: ["main"])])
     store.setRunConfig(RunConfig(command: "echo hi", autoRun: false), forProject: "/a")


### PR DESCRIPTION
## What

Adds a global setting — **"Open a terminal in new workrooms"** (Settings window, ⌘,) — that, when on, opens a plain shell terminal in a newly created workroom. Off by default, so existing behaviour is unchanged (a created workroom shows the empty state unless a run command auto-runs).

The terminal fires at the **post-setup mount point**: the workroom's terminal pane is withheld behind the blocking setup-script dialog, so the shell opens only *after any setup script runs and its overlay is dismissed*.

## Run-command interaction

The setting is independent of a project's run-command auto-run. On create, after setup is dismissed:

| `openTerminalOnCreate` | auto-run command | result |
|---|---|---|
| off | off | empty state (unchanged) |
| off | on | run command = tab #1 (unchanged) |
| on  | off | one shell terminal |
| on  | on  | run command = tab #1 (focused) **+** shell = tab #2 |

Selecting an *existing* workroom never auto-opens a terminal (issue #23 preserved) — the intent is a one-shot create-time marker (`pendingOpenTerminal`, mirroring auto-run arming), consumed once in `ensureInitialTerminal`.

A shell opens even when the setup script **fails** (a plain shell is safe and useful for investigating); only auto-run is disarmed on failure, as before.

## Changes

- `Core/DefaultsKeys.swift` — `openTerminalOnCreate` key (`"openTerminalOnWorkroomCreate"`, default `false`).
- `Core/AppStore.swift` — `pendingOpenTerminal` marker + `armOpenTerminal(...)`; rewrote `ensureInitialTerminal` to consume both intents; armed in `createWorkroom`'s `onReady`; cleared on delete-before-mount.
- `Views/SettingsView.swift` — the toggle.
- `WorkroomAppTests/RunCommandTests.swift` — 3 tests: shell-only, both-with-run-tab-focused, one-shot re-mount.

## Test

Build ✅ · `make app-test` ✅ (incl. 3 new) · `make app-lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)