### PR TITLE
feat(macapp): show per-reviewer status in the PR panel (#52)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -356,3 +356,50 @@ per workroom when logged out" optimization it currently buys (`:70-73`), and rew
 
 **Priority:** P3 (the `--active` fix covers the reported bug and current gh; revisit only if
 multi-host or old-gh false-negatives get reported).
+
+## Per-reviewer comment counts in the PR panel (macapp) — #52 follow-up
+
+**What:** Show a per-reviewer comment count next to each reviewer row in the Pull Request panel,
+e.g. `iainad approved · 3 comments` — the `[N comments]` part of the issue #52 mockup.
+
+**Current state:** #52 shipped the per-reviewer rows (state + bot-aware "in progress" label) by
+riding the existing `gh pr list --head … --json …` probe, which carries `latestReviews` /
+`reviewRequests` but **no review-comment counts**. The rows show state only.
+
+**Why:** richer signal at a glance — how much feedback a reviewer left, not just their verdict.
+
+**How to start:** counts aren't in `latestReviews`, so this needs a second call —
+`gh api repos/{owner}/{repo}/pulls/{number}/comments` (review/diff comments) grouped by
+`user.login` — added to `resolvePR` (`Core/WorkroomStatusResolver.swift`) and surfaced on
+`Reviewer` (e.g. an optional `commentCount`). Weigh the extra network round-trip on the already-slow,
+TTL-throttled PR probe; consider fetching counts lazily/only for the selected PR. Map counts onto
+the existing identity-keyed fold; teams won't have counts.
+
+**Depends on:** the #52 reviewer rows (shipped).
+
+**Priority:** P3 (nice-to-have; deliberately deferred from #52 to keep that change to free data).
+
+## At-a-glance review status in the sidebar / collapsed PR header (macapp) — #52 follow-up
+
+**What:** Surface a compact review-status glyph (the aggregate `reviewDecision` — approved /
+changes-requested / review-required) on the sidebar workroom row or the collapsed "Pull Request"
+section header, next to the existing CI glyph — so review state is visible without expanding the
+panel. Directly serves issue #52's framing ("so we can go visit the PR when needed").
+
+**Current state:** #52 shows reviewers (and the kept `reviewDecision` aggregate) only in the
+**expanded** Pull Request inspector panel. The aggregate is the natural feed for a glyph.
+
+**Why:** a glance from the sidebar beats expanding the panel per workroom; matches how CI status
+already reads at a glance.
+
+**How to start:** the blocker is data freshness — the PR (and thus `reviewDecision`) is resolved
+**only on selection** (`scheduleSelectedStatusRefresh`), not in the bounded background sweep
+(`refreshWorkroomStatuses` / `runCISweep` in `Core/AppStore+WorkroomStatus.swift`). A sidebar glyph
+needs PR resolution added to the sweep (a third probe stage, bounded like CI, with its own TTL), then
+a `VCSStatusPresentation`-style mapper for the review glyph reused by the sidebar row + collapsed
+header (`ChangesPanel.prIndicator`).
+
+**Depends on:** the #52 `reviewDecision` aggregate (shipped). Bigger than a UI tweak — it adds a PR
+sweep stage.
+
+**Priority:** P3 (strong UX win, but the background-sweep work makes it its own chunk, not part of #52).

--- a/macapp/WorkroomApp/Core/AppStore+WorkroomStatus.swift
+++ b/macapp/WorkroomApp/Core/AppStore+WorkroomStatus.swift
@@ -193,7 +193,7 @@ extension AppStore {
     }
     s.pr = PullRequestInfo(
       number: pr.number, title: pr.title, state: state, isDraft: draft, url: pr.url,
-      reviewDecision: pr.reviewDecision)
+      reviewDecision: pr.reviewDecision, reviewers: pr.reviewers)
     workroomStatuses[sid] = s
   }
 

--- a/macapp/WorkroomApp/Core/UITestFixture.swift
+++ b/macapp/WorkroomApp/Core/UITestFixture.swift
@@ -73,7 +73,14 @@ enum UITestFixture {
       jjChangeID: "pw", jjCommitID: "7d74470b",
       pr: PullRequestInfo(
         number: 42, title: "Add session login", state: .open, isDraft: false,
-        url: "https://github.com/acme/app/pull/42", reviewDecision: .approved),
+        url: "https://github.com/acme/app/pull/42", reviewDecision: .changesRequested,
+        // A spread of reviewer states so the panel renders the aggregate header + every row kind:
+        // a bot still generating, a human approval, and a human requesting changes.
+        reviewers: [
+          Reviewer(identity: .user(login: "copilot-pull-request-reviewer"), state: .requested),
+          Reviewer(identity: .user(login: "iainad"), state: .approved),
+          Reviewer(identity: .user(login: "octocat"), state: .changesRequested),
+        ]),
       // All three "checked" stamps set so the inspector shows the seeded data, not "Checking…".
       lastChecked: Self.checkedAt, ciCheckedAt: Self.checkedAt, prCheckedAt: Self.checkedAt)
   }

--- a/macapp/WorkroomApp/Core/WorkroomStatus.swift
+++ b/macapp/WorkroomApp/Core/WorkroomStatus.swift
@@ -87,12 +87,41 @@ struct ChangedFile: Equatable, Hashable, Identifiable, Sendable {
   var id: String { "\(change.rawValue):\(path)" }
 }
 
+/// One reviewer on a pull request (issue #52): either someone who has *submitted* a review
+/// (`latestReviews`) or someone who's been *requested* but hasn't yet (`reviewRequests`). The
+/// identity is typed so a requested team (which has a `slug`, not a `login`) can never collide
+/// with a user in the dedup. Pure data — the per-reviewer glyph/label/sort live in `PRPresentation`.
+struct Reviewer: Equatable, Sendable, Identifiable {
+  /// A user (keyed by GitHub `login`) or a requested team (keyed by `slug`). Prefixed in `id` so
+  /// `user:octocat` and `team:octocat` are distinct keys.
+  enum Identity: Equatable, Sendable, Hashable {
+    case user(login: String)
+    case team(slug: String)
+  }
+  /// `requested` = in `reviewRequests` (asked, no submitted review yet). The rest mirror GitHub's
+  /// submitted-review states; an unrecognised state is dropped at parse time, never stored.
+  enum State: Equatable, Sendable {
+    case requested
+    case approved, changesRequested, commented, dismissed
+  }
+  let identity: Identity
+  let state: State
+  var id: String {
+    switch identity {
+    case .user(let login): return "user:\(login)"
+    case .team(let slug): return "team:\(slug)"
+    }
+  }
+}
+
 /// The pull request for a workroom's branch (Phase 2), resolved via `gh pr list --head`. Read-only
 /// in this iteration — the Pull Request inspector section shows it; create/merge/etc. come later.
 struct PullRequestInfo: Equatable, Sendable {
   /// GitHub's PR `state` (a draft is still `open` — see `isDraft`).
   enum State: String, Equatable, Sendable { case open, merged, closed }
-  /// GitHub's `reviewDecision`; `nil` when no review is required or none has been given yet.
+  /// GitHub's `reviewDecision`; `nil` when no review is required or none has been given yet. Kept
+  /// (issue #52) as the aggregate header above the per-reviewer rows — branch-protection/CODEOWNERS
+  /// can require a review with no concrete reviewer rows, so the rows alone can't carry this signal.
   enum ReviewDecision: String, Equatable, Sendable {
     case approved, changesRequested, reviewRequired
   }
@@ -102,6 +131,10 @@ struct PullRequestInfo: Equatable, Sendable {
   let isDraft: Bool
   let url: String
   let reviewDecision: ReviewDecision?
+  /// Per-reviewer status (issue #52). No default: every construction site must pass it, so the
+  /// compiler — not a runtime test — guarantees a rebuild (e.g. `applyFixturePRAction`) can't
+  /// silently drop reviewers. Order is not significant here; `PRPresentation.reviewers` sorts.
+  let reviewers: [Reviewer]
 }
 
 /// A point-in-time snapshot of one workroom's VCS + CI status, resolved app-side.
@@ -282,7 +315,8 @@ enum PRPresentation {
     }
   }
 
-  /// Human label for the review decision, or nil when there's nothing to announce.
+  /// Human label for the aggregate review decision (the header above the per-reviewer rows), or nil
+  /// when there's nothing to announce.
   static func reviewLabel(_ decision: PullRequestInfo.ReviewDecision?) -> String? {
     switch decision {
     case .approved: return "Approved"
@@ -290,5 +324,94 @@ enum PRPresentation {
     case .reviewRequired: return "Review required"
     case nil: return nil
     }
+  }
+
+  // MARK: Per-reviewer rows (issue #52)
+
+  enum ReviewSemantic: Equatable {
+    case approved, changesRequested, commented, requested, dismissed
+  }
+  /// One reviewer row: SF Symbol + semantic + a human/bot-aware state label. `id` is the reviewer's
+  /// collision-free identity (`user:` / `team:`), so it's a stable, unique `ForEach` key.
+  struct ReviewerBadge: Equatable, Identifiable {
+    let id: String
+    let displayName: String  // bot-friendly (e.g. "Copilot"); team → its slug
+    let symbol: String
+    let semantic: ReviewSemantic
+    let stateLabel: String
+    let accessibility: String
+  }
+
+  /// The reviewer rows for the PR panel, sorted by attention (changes-requested first) then `id`
+  /// for determinism. This is the ONLY place reviewer order is decided. Pure → unit-testable.
+  static func reviewers(_ pr: PullRequestInfo) -> [ReviewerBadge] {
+    pr.reviewers
+      .sorted { lhs, rhs in
+        let l = sortRank(lhs.state)
+        let r = sortRank(rhs.state)
+        return l == r ? lhs.id < rhs.id : l < r
+      }
+      .map(badge(for:))
+  }
+
+  private static func sortRank(_ s: Reviewer.State) -> Int {
+    switch s {
+    case .changesRequested: return 0
+    case .requested: return 1
+    case .commented: return 2
+    case .approved: return 3
+    case .dismissed: return 4
+    }
+  }
+
+  private static func badge(for r: Reviewer) -> ReviewerBadge {
+    let name = displayName(r.identity)
+    let symbol: String
+    let semantic: ReviewSemantic
+    let label: String
+    switch r.state {
+    case .approved:
+      symbol = "checkmark.circle.fill"
+      semantic = .approved
+      label = "approved"
+    case .changesRequested:
+      symbol = "xmark.circle.fill"
+      semantic = .changesRequested
+      label = "changes requested"
+    case .commented:
+      symbol = "text.bubble"
+      semantic = .commented
+      label = "commented"
+    case .requested:
+      // A bot in `reviewRequests` is actively generating ("in progress"); a human just hasn't
+      // started yet ("review requested"). The API can't tell us more.
+      symbol = "clock.arrow.circlepath"
+      semantic = .requested
+      label = isBot(r.identity) ? "in progress" : "review requested"
+    case .dismissed:
+      symbol = "minus.circle"
+      semantic = .dismissed
+      label = "dismissed"
+    }
+    return ReviewerBadge(
+      id: r.id, displayName: name, symbol: symbol, semantic: semantic, stateLabel: label,
+      accessibility: "\(name) \(label)")
+  }
+
+  /// Display name: friendly for known bots, the team slug for teams, else the raw login.
+  static func displayName(_ identity: Reviewer.Identity) -> String {
+    switch identity {
+    case .team(let slug): return slug
+    case .user(let login):
+      if login == "copilot-pull-request-reviewer" { return "Copilot" }
+      if login.hasSuffix("[bot]") { return String(login.dropLast("[bot]".count)) }
+      return login
+    }
+  }
+
+  /// Whether this identity is a bot — drives "in progress" vs "review requested". Teams are humans.
+  static func isBot(_ identity: Reviewer.Identity) -> Bool {
+    guard case .user(let login) = identity else { return false }
+    return login.hasSuffix("[bot]") || login == "copilot-pull-request-reviewer"
   }
 }

--- a/macapp/WorkroomApp/Core/WorkroomStatusResolver.swift
+++ b/macapp/WorkroomApp/Core/WorkroomStatusResolver.swift
@@ -154,7 +154,7 @@ struct WorkroomStatusResolver: Sendable {
       "gh",
       [
         "pr", "list", "--head", target.branch, "--state", "all", "--limit", "1", "--json",
-        "number,title,state,isDraft,url,reviewDecision",
+        "number,title,state,isDraft,url,reviewDecision,latestReviews,reviewRequests",
       ], in: target.dir, timeout: ciTimeout)
     return Self.classifyPR(r)
   }
@@ -514,6 +514,19 @@ struct WorkroomStatusResolver: Sendable {
     case .proceed: break
     }
 
+    // `latestReviews` = the latest submitted review per author; `reviewRequests` = pending reviewers
+    // (users by `login`, teams by `slug`). Both optional so JSON that omits them (old/other callers)
+    // decodes cleanly to an empty reviewer list — only a *present-but-malformed* payload fails the
+    // whole decode and trips `.keepPrior` below, so we never silently blank reviewers on a parse error.
+    struct RawAuthor: Decodable { let login: String? }
+    struct RawReview: Decodable {
+      let author: RawAuthor?
+      let state: String?
+    }
+    struct RawRequest: Decodable {
+      let login: String?  // present for user reviewers
+      let slug: String?  // present for team reviewers (with `name`); `__typename` is ignored
+    }
     struct Raw: Decodable {
       let number: Int
       let title: String
@@ -521,6 +534,8 @@ struct WorkroomStatusResolver: Sendable {
       let isDraft: Bool
       let url: String
       let reviewDecision: String?
+      let latestReviews: [RawReview]?
+      let reviewRequests: [RawRequest]?
     }
     // Malformed/truncated JSON (a gh schema change, or output capped mid-stream) must NOT erase the
     // PR badge. A *valid* empty array is different — that genuinely means no PR (handled below).
@@ -545,9 +560,41 @@ struct WorkroomStatusResolver: Sendable {
     case "REVIEW_REQUIRED": review = .reviewRequired
     default: review = nil  // "" or absent → no decision to show
     }
+
+    // Fold the two review arrays into one list keyed by reviewer identity. `latestReviews` is the
+    // latest submitted review per author (so a login appears at most once — the keyed insert is
+    // idempotent). `reviewRequests` then OVERRIDES: a re-requested reviewer is pending again even if
+    // a stale submitted review exists. Order is irrelevant — `PRPresentation.reviewers` sorts.
+    var reviewersByID: [String: Reviewer] = [:]
+    for rev in raw.latestReviews ?? [] {
+      guard let login = rev.author?.login, !login.isEmpty else { continue }
+      let st: Reviewer.State
+      switch rev.state?.uppercased() {
+      case "APPROVED": st = .approved
+      case "CHANGES_REQUESTED": st = .changesRequested
+      case "COMMENTED": st = .commented
+      case "DISMISSED": st = .dismissed
+      default: continue  // unrecognised state (e.g. a future GitHub value, PENDING) → don't render
+      }
+      let reviewer = Reviewer(identity: .user(login: login), state: st)
+      reviewersByID[reviewer.id] = reviewer
+    }
+    for req in raw.reviewRequests ?? [] {
+      let identity: Reviewer.Identity
+      if let login = req.login, !login.isEmpty {
+        identity = .user(login: login)
+      } else if let slug = req.slug, !slug.isEmpty {
+        identity = .team(slug: slug)
+      } else {
+        continue  // no usable identifier
+      }
+      let reviewer = Reviewer(identity: identity, state: .requested)
+      reviewersByID[reviewer.id] = reviewer
+    }
+
     return .info(
       PullRequestInfo(
         number: raw.number, title: raw.title, state: state, isDraft: raw.isDraft, url: raw.url,
-        reviewDecision: review))
+        reviewDecision: review, reviewers: Array(reviewersByID.values)))
   }
 }

--- a/macapp/WorkroomApp/Views/PullRequestPanel.swift
+++ b/macapp/WorkroomApp/Views/PullRequestPanel.swift
@@ -101,8 +101,22 @@ struct PullRequestPanel: View {
       .font(.callout)
       .foregroundStyle(.primary)
       .lineLimit(2).truncationMode(.tail)
+    // Aggregate decision header (issue #52): always shown when GitHub reports one, so a
+    // branch-protected PR that's REVIEW_REQUIRED with no named reviewers still shows a signal.
     if let review = PRPresentation.reviewLabel(pr.reviewDecision) {
       Text(review).font(.footnote).foregroundStyle(.secondary)
+    }
+    // One row per reviewer: state glyph + name + state label (e.g. "Copilot in progress",
+    // "iainad approved"). Glyph + label carry the meaning without relying on color.
+    ForEach(PRPresentation.reviewers(pr)) { reviewer in
+      HStack(spacing: 6) {
+        Image(systemName: reviewer.symbol).foregroundStyle(reviewer.semantic.color)
+        Text(reviewer.displayName).font(.footnote).lineLimit(1).truncationMode(.tail)
+        Text(reviewer.stateLabel).font(.footnote).foregroundStyle(.secondary)
+        Spacer(minLength: 0)
+      }
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(reviewer.accessibility)
     }
   }
 
@@ -158,6 +172,20 @@ extension PRPresentation.Semantic {
     case .draft: return .secondary
     case .merged: return .purple
     case .closed: return .red
+    }
+  }
+}
+
+extension PRPresentation.ReviewSemantic {
+  /// Semantic → SwiftUI color for a per-reviewer row glyph. Mirrors GitHub: approved green,
+  /// changes-requested red, pending amber; commented/dismissed stay quiet (the glyph carries it).
+  var color: Color {
+    switch self {
+    case .approved: return .green
+    case .changesRequested: return .red
+    case .requested: return .orange
+    case .commented: return .secondary
+    case .dismissed: return .secondary
     }
   }
 }

--- a/macapp/WorkroomAppTests/WorkroomStatusResolverTests.swift
+++ b/macapp/WorkroomAppTests/WorkroomStatusResolverTests.swift
@@ -482,6 +482,7 @@ final class WorkroomStatusResolverTests: XCTestCase {
     XCTAssertFalse(pr.isDraft)
     XCTAssertEqual(pr.url, "https://x/42")
     XCTAssertEqual(pr.reviewDecision, .approved)
+    XCTAssertTrue(pr.reviewers.isEmpty)  // back-compat: JSON without review fields → no rows
   }
 
   func testClassifyPRDraftEmptyReviewIsNil() {
@@ -561,6 +562,73 @@ final class WorkroomStatusResolverTests: XCTestCase {
       #"[{"number":3,"title":"t","state":"LOCKED","isDraft":false,"url":"u","reviewDecision":null}]"#
     )
     XCTAssertEqual(WorkroomStatusResolver.classifyPR(r), .keepPrior)
+  }
+
+  // MARK: - classifyPR reviewers (issue #52)
+
+  func testClassifyPRParsesReviewers() {
+    let r = ok(
+      #"[{"number":1,"title":"t","state":"OPEN","isDraft":false,"url":"u","reviewDecision":"CHANGES_REQUESTED","latestReviews":[{"author":{"login":"iainad"},"state":"APPROVED"},{"author":{"login":"octocat"},"state":"CHANGES_REQUESTED"},{"author":{"login":"carl"},"state":"COMMENTED"},{"author":{"login":"dot"},"state":"DISMISSED"}],"reviewRequests":[{"login":"copilot-pull-request-reviewer"}]}]"#
+    )
+    guard case .info(let pr) = WorkroomStatusResolver.classifyPR(r) else { return XCTFail() }
+    XCTAssertEqual(pr.reviewDecision, .changesRequested)
+    let byID = Dictionary(uniqueKeysWithValues: pr.reviewers.map { ($0.id, $0.state) })
+    XCTAssertEqual(byID["user:iainad"], .approved)
+    XCTAssertEqual(byID["user:octocat"], .changesRequested)
+    XCTAssertEqual(byID["user:carl"], .commented)
+    XCTAssertEqual(byID["user:dot"], .dismissed)
+    XCTAssertEqual(byID["user:copilot-pull-request-reviewer"], .requested)
+    XCTAssertEqual(pr.reviewers.count, 5)
+  }
+
+  /// A reviewer who submitted a review and was then RE-requested shows as pending again
+  /// (reviewRequests overrides the stale submitted review).
+  func testClassifyPRReviewRequestsWin() {
+    let r = ok(
+      #"[{"number":1,"title":"t","state":"OPEN","isDraft":false,"url":"u","reviewDecision":"REVIEW_REQUIRED","latestReviews":[{"author":{"login":"octocat"},"state":"CHANGES_REQUESTED"}],"reviewRequests":[{"login":"octocat"}]}]"#
+    )
+    guard case .info(let pr) = WorkroomStatusResolver.classifyPR(r) else { return XCTFail() }
+    XCTAssertEqual(pr.reviewers.count, 1)
+    XCTAssertEqual(pr.reviewers.first?.id, "user:octocat")
+    XCTAssertEqual(pr.reviewers.first?.state, .requested)
+  }
+
+  func testClassifyPRTeamReviewRequest() {
+    let r = ok(
+      #"[{"number":1,"title":"t","state":"OPEN","isDraft":false,"url":"u","reviewDecision":null,"latestReviews":[],"reviewRequests":[{"__typename":"Team","name":"Platform","slug":"platform"}]}]"#
+    )
+    guard case .info(let pr) = WorkroomStatusResolver.classifyPR(r) else { return XCTFail() }
+    XCTAssertEqual(pr.reviewers.count, 1)
+    XCTAssertEqual(pr.reviewers.first?.identity, .team(slug: "platform"))
+    XCTAssertEqual(pr.reviewers.first?.state, .requested)
+  }
+
+  /// A future/unknown review state (e.g. PENDING) is dropped, not rendered; known ones survive.
+  func testClassifyPRSkipsUnknownReviewState() {
+    let r = ok(
+      #"[{"number":1,"title":"t","state":"OPEN","isDraft":false,"url":"u","reviewDecision":null,"latestReviews":[{"author":{"login":"a"},"state":"PENDING"},{"author":{"login":"b"},"state":"APPROVED"}],"reviewRequests":[]}]"#
+    )
+    guard case .info(let pr) = WorkroomStatusResolver.classifyPR(r) else { return XCTFail() }
+    XCTAssertEqual(pr.reviewers.map(\.id), ["user:b"])
+  }
+
+  /// A review with no author login, and a request with neither login nor slug, are skipped.
+  func testClassifyPRSkipsReviewerWithoutIdentity() {
+    let r = ok(
+      #"[{"number":1,"title":"t","state":"OPEN","isDraft":false,"url":"u","reviewDecision":null,"latestReviews":[{"author":null,"state":"APPROVED"}],"reviewRequests":[{"login":null,"slug":null}]}]"#
+    )
+    guard case .info(let pr) = WorkroomStatusResolver.classifyPR(r) else { return XCTFail() }
+    XCTAssertTrue(pr.reviewers.isEmpty)
+  }
+
+  /// REGRESSION: JSON omitting the review fields must still resolve to a PR with no reviewer rows.
+  func testClassifyPRBackCompatNoReviewFields() {
+    let r = ok(
+      #"[{"number":9,"title":"t","state":"OPEN","isDraft":false,"url":"u","reviewDecision":"APPROVED"}]"#
+    )
+    guard case .info(let pr) = WorkroomStatusResolver.classifyPR(r) else { return XCTFail() }
+    XCTAssertEqual(pr.reviewDecision, .approved)
+    XCTAssertTrue(pr.reviewers.isEmpty)
   }
 
   // MARK: - resolvePR (end-to-end via the mock)

--- a/macapp/WorkroomAppTests/WorkroomStatusTests.swift
+++ b/macapp/WorkroomAppTests/WorkroomStatusTests.swift
@@ -232,7 +232,8 @@ final class WorkroomStatusTests: XCTestCase {
 
   private func pr(_ state: PullRequestInfo.State, draft: Bool = false) -> PullRequestInfo {
     PullRequestInfo(
-      number: 1, title: "t", state: state, isDraft: draft, url: "u", reviewDecision: nil)
+      number: 1, title: "t", state: state, isDraft: draft, url: "u", reviewDecision: nil,
+      reviewers: [])
   }
 
   func testPRBadgeStates() {
@@ -252,6 +253,106 @@ final class WorkroomStatusTests: XCTestCase {
     XCTAssertNil(PRPresentation.reviewLabel(nil))
   }
 
+  // MARK: - PRPresentation.reviewers (issue #52: per-reviewer rows)
+
+  private func prWithReviewers(_ reviewers: [Reviewer]) -> PullRequestInfo {
+    PullRequestInfo(
+      number: 1, title: "t", state: .open, isDraft: false, url: "u", reviewDecision: nil,
+      reviewers: reviewers)
+  }
+
+  func testReviewersEmpty() {
+    XCTAssertTrue(PRPresentation.reviewers(prWithReviewers([])).isEmpty)
+  }
+
+  func testReviewersStateMapping() {
+    let badges = PRPresentation.reviewers(
+      prWithReviewers([
+        Reviewer(identity: .user(login: "a"), state: .approved),
+        Reviewer(identity: .user(login: "b"), state: .changesRequested),
+        Reviewer(identity: .user(login: "c"), state: .commented),
+        Reviewer(identity: .user(login: "d"), state: .dismissed),
+        Reviewer(identity: .user(login: "e"), state: .requested),
+      ]))
+    func badge(_ login: String) -> PRPresentation.ReviewerBadge {
+      badges.first { $0.id == "user:\(login)" }!
+    }
+    XCTAssertEqual(badge("a").symbol, "checkmark.circle.fill")
+    XCTAssertEqual(badge("a").semantic, .approved)
+    XCTAssertEqual(badge("a").stateLabel, "approved")
+    XCTAssertEqual(badge("b").symbol, "xmark.circle.fill")
+    XCTAssertEqual(badge("b").semantic, .changesRequested)
+    XCTAssertEqual(badge("b").stateLabel, "changes requested")
+    XCTAssertEqual(badge("c").symbol, "text.bubble")
+    XCTAssertEqual(badge("c").stateLabel, "commented")
+    XCTAssertEqual(badge("d").symbol, "minus.circle")
+    XCTAssertEqual(badge("d").stateLabel, "dismissed")
+    XCTAssertEqual(badge("e").symbol, "clock.arrow.circlepath")
+    XCTAssertEqual(badge("e").stateLabel, "review requested")  // human pending
+    XCTAssertEqual(badge("a").accessibility, "a approved")
+  }
+
+  /// Sort: changes-requested → requested → commented → approved → dismissed, then id A–Z.
+  func testReviewersSortOrder() {
+    let badges = PRPresentation.reviewers(
+      prWithReviewers([
+        Reviewer(identity: .user(login: "z"), state: .approved),
+        Reviewer(identity: .user(login: "a"), state: .dismissed),
+        Reviewer(identity: .user(login: "m"), state: .changesRequested),
+        Reviewer(identity: .user(login: "n"), state: .requested),
+        Reviewer(identity: .user(login: "p"), state: .commented),
+      ]))
+    XCTAssertEqual(badges.map(\.id), ["user:m", "user:n", "user:p", "user:z", "user:a"])
+  }
+
+  func testReviewersSortTieBrokenByID() {
+    let badges = PRPresentation.reviewers(
+      prWithReviewers([
+        Reviewer(identity: .user(login: "bob"), state: .approved),
+        Reviewer(identity: .user(login: "amy"), state: .approved),
+      ]))
+    XCTAssertEqual(badges.map(\.id), ["user:amy", "user:bob"])
+  }
+
+  func testReviewersBotLabelAndName() {
+    let copilot = PRPresentation.reviewers(
+      prWithReviewers([
+        Reviewer(identity: .user(login: "copilot-pull-request-reviewer"), state: .requested)
+      ])
+    ).first!
+    XCTAssertEqual(copilot.displayName, "Copilot")
+    XCTAssertEqual(copilot.stateLabel, "in progress")  // bot pending → in progress
+    XCTAssertEqual(copilot.accessibility, "Copilot in progress")
+
+    let appBot = PRPresentation.reviewers(
+      prWithReviewers([
+        Reviewer(identity: .user(login: "dependabot[bot]"), state: .requested)
+      ])
+    ).first!
+    XCTAssertEqual(appBot.displayName, "dependabot")
+    XCTAssertEqual(appBot.stateLabel, "in progress")
+  }
+
+  func testReviewersTeamDisplay() {
+    let team = PRPresentation.reviewers(
+      prWithReviewers([Reviewer(identity: .team(slug: "platform"), state: .requested)])
+    ).first!
+    XCTAssertEqual(team.id, "team:platform")
+    XCTAssertEqual(team.displayName, "platform")
+    XCTAssertEqual(team.stateLabel, "review requested")  // teams are non-bot
+  }
+
+  /// A team slug and a user login sharing a string must NOT collide into one row.
+  func testReviewerIdentityNoCollision() {
+    let badges = PRPresentation.reviewers(
+      prWithReviewers([
+        Reviewer(identity: .user(login: "octo"), state: .approved),
+        Reviewer(identity: .team(slug: "octo"), state: .requested),
+      ]))
+    XCTAssertEqual(badges.count, 2)
+    XCTAssertEqual(Set(badges.map(\.id)), ["user:octo", "team:octo"])
+  }
+
   /// A local refresh must preserve the separately-probed PR (like CI) — mergeLocalStatus must not
   /// drop it.
   @MainActor
@@ -262,9 +363,11 @@ final class WorkroomStatusTests: XCTestCase {
     store.workroomStatuses[sid] = WorkroomStatus(
       dirty: true,
       pr: PullRequestInfo(
-        number: 5, title: "t", state: .open, isDraft: false, url: "u", reviewDecision: .approved))
+        number: 5, title: "t", state: .open, isDraft: false, url: "u", reviewDecision: .approved,
+        reviewers: [Reviewer(identity: .user(login: "iainad"), state: .approved)]))
     store.mergeLocalStatus(WorkroomStatus(dirty: false, branchForCI: "main"), into: sid)
     XCTAssertEqual(store.workroomStatuses[sid]?.pr?.number, 5)  // PR survives the local refresh
+    XCTAssertEqual(store.workroomStatuses[sid]?.pr?.reviewers.count, 1)  // …with its reviewers
   }
 
   /// The deleted-mid-sweep guard: a status sweep captures its work-list up front, so a workroom
@@ -298,7 +401,8 @@ final class WorkroomStatusTests: XCTestCase {
   func testPRActionAvailability() {
     func pr(_ state: PullRequestInfo.State, draft: Bool = false) -> PullRequestInfo {
       PullRequestInfo(
-        number: 1, title: "t", state: state, isDraft: draft, url: "u", reviewDecision: nil)
+        number: 1, title: "t", state: state, isDraft: draft, url: "u", reviewDecision: nil,
+        reviewers: [])
     }
     XCTAssertEqual(PRAction.available(for: pr(.open)), [.convertToDraft, .close])
     XCTAssertEqual(PRAction.available(for: pr(.open, draft: true)), [.markReady, .close])


### PR DESCRIPTION
Closes #52.

## What

The Pull Request inspector now shows **per-reviewer status** — who approved, who requested changes, who is still pending — beneath the aggregate review-decision header. Tells you at a glance when reviews are requested vs in, and when to go visit the PR.

```
Changes requested              ← aggregate decision header
✗ octocat   changes requested
⏱ Copilot   in progress         ← bots → "in progress"; humans → "review requested"
✓ iainad    approved
```

## How

- Reviews ride the **existing** `gh pr list --head … --json` probe via two new fields (`latestReviews`, `reviewRequests`) — no extra API call.
- `classifyPR` folds them into a typed, deduped `[Reviewer]`: `.user(login)` / `.team(slug)` identity (a team can't collide with a user), `reviewRequests` wins on re-request, unrecognised review states skipped, missing fields → `[]`, malformed → `keepPrior`.
- `PRPresentation.reviewers(_:)` is the single sort + map seam → rows with bot-aware labels ("in progress" for bots like Copilot, "review requested" for humans) and friendly names.
- The aggregate `reviewDecision` is **kept** as a header above the rows, so a branch-protected `REVIEW_REQUIRED` PR with no named reviewers still shows a signal.

## Tests

`make app-build` / `app-test` (429 pass, +15 review tests) / `app-lint` — all green. Covers review parse / dedup / team / skip-unknown / decoder back-compat regression; presentation sort / state mapping / bot-aware / team / no-collision.

## Not in scope (tracked in `TODOS.md`)

- Per-reviewer comment counts (`[N comments]`) — needs a second `gh api` call.
- At-a-glance review status in the sidebar / collapsed header — needs PR resolution in the background sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
