### PR TITLE
Open root terminal after adding a project

### DIFF
--- a/macapp/WorkroomApp/Core/AppStore.swift
+++ b/macapp/WorkroomApp/Core/AppStore.swift
@@ -1840,12 +1840,16 @@ final class AppStore: ObservableObject {
     do {
       try await WorkroomCLI.shared.addProject(url.path)
       await reload()
-      // Select the freshly added project as context (no target — the root is one click away).
+      // Select the freshly added project and open a terminal on its root — mirroring workroom
+      // creation, which lands the user in a live terminal rather than the "Nothing selected" empty
+      // state (issue #104). Selecting the root target mounts its terminal view, which opens the
+      // initial shell via `ensureInitialTerminal`. A new project has no workrooms, so the root is
+      // the only sensible terminal to open.
       if let match = projects.first(where: {
         $0.path == url.path || ($0.path as NSString).lastPathComponent == url.lastPathComponent
       }) {
         selectedProjectID = match.id
-        selectedTargetID = nil
+        selectedTargetID = .root(project: match.path)
       }
     } catch {
       present(error)


### PR DESCRIPTION
## Summary

Adding a project in the macOS app left the user on the empty "Nothing selected" detail view: the project was selected as sidebar context, but no terminal target was selected, so a terminal only appeared after manually clicking the project root. Creating a workroom, by contrast, lands the user directly in a live terminal.

This makes add-project consistent with workroom creation by selecting the project's **root** target after reload, which mounts its terminal view and opens the initial shell via `ensureInitialTerminal`.

Fixes #104

## Changes

- `macapp/WorkroomApp/Core/AppStore.swift` — in `addProject(_:)`, replace `selectedTargetID = nil` with `selectedTargetID = .root(project: match.path)` (plus an updated comment). This mirrors `mountSetupLog`'s target selection. A freshly added project has no workrooms yet, so the root is the only sensible terminal to open.

## Verification

This is a macOS/Xcode project and was developed in a Linux environment, so the build/lint/run targets could not be executed here. Before merging, please verify on a Mac:

- `make app-build` — confirm it compiles.
- `make app-lint` — swift-format strict gate.
- `make app-run` — click "+" in the sidebar, pick a Git repo, and confirm a terminal opens on the project root automatically (instead of "Nothing selected"). Compare against creating a workroom to confirm consistent behavior.

There are no existing unit tests referencing `addProject`; the flow depends on SwiftUI view mounting (`ensureInitialTerminal` fires from a `.task` modifier), so it is verified via the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mG8ik2LKkBh7zqdX3eCHt

---
_Generated by [Claude Code](https://claude.ai/code/session_011mG8ik2LKkBh7zqdX3eCHt)_