### PR TITLE
feat(macapp): split a workroom by dragging from the sidebar (#101)

### DIFF
--- a/macapp/WorkroomApp/Views/EdgeRevealSidebar.swift
+++ b/macapp/WorkroomApp/Views/EdgeRevealSidebar.swift
@@ -283,6 +283,12 @@ struct EdgeRevealSidebars: ViewModifier {
   @EnvironmentObject private var store: AppStore
   let sidebarVisible: Bool
   let inspectorVisible: Bool
+  /// Drag-to-split plumbing for the revealed Projects panel (issue #101) — same as the docked
+  /// `SidebarColumn`'s, so dragging a row out of the slide-over forms a split too. The panel floats
+  /// over the same detail content, so it resolves against the same frame.
+  var paneDrag: Binding<WorkroomPaneDrag?> = .constant(nil)
+  var localize: (CGPoint) -> CGPoint? = { _ in nil }
+  var dropTarget: (CGPoint) -> (sid: SidebarID, edge: PaneEdge)? = { _ in nil }
 
   func body(content: Content) -> some View {
     content
@@ -290,7 +296,7 @@ struct EdgeRevealSidebars: ViewModifier {
         EdgeRevealSidebar(
           side: .leading, enabled: !sidebarVisible, width: store.dockedSidebarWidth ?? 260
         ) {
-          ProjectSidebar()
+          ProjectSidebar(paneDrag: paneDrag, localize: localize, dropTarget: dropTarget)
         }
       }
       .overlay {

--- a/macapp/WorkroomApp/Views/ProjectSidebar.swift
+++ b/macapp/WorkroomApp/Views/ProjectSidebar.swift
@@ -13,6 +13,18 @@ struct ProjectSidebar: View {
   @EnvironmentObject var notifications: NotificationCenterStore
   @EnvironmentObject var terminals: TerminalSessions
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  /// Live drag of a root/workroom row into the detail content to form a workroom split (issue #101) —
+  /// the same pipeline the title-bar tab bar uses (`WorkroomTabBar`). Bound to `RootView`'s
+  /// `workroomChipDrag` so `WorkroomSplitView.externalDrag` highlights the drop edge while dragging.
+  /// The defaults make the gesture an inert no-op for previews / any host that doesn't wire it.
+  var paneDrag: Binding<WorkroomPaneDrag?> = .constant(nil)
+  /// Maps a global drag point into detail-content-local coords, or nil when it's outside the detail
+  /// area (→ not a drop). Owned by `RootView` (it knows the content frame).
+  var localize: (CGPoint) -> CGPoint? = { _ in nil }
+  /// Where a drop at a global point lands (workroom pane + edge), or nil if it isn't over a pane.
+  var dropTarget: (CGPoint) -> (sid: SidebarID, edge: PaneEdge)? = { _ in nil }
+
   @State private var hovered: SidebarID?
   /// The terminal row currently under the cursor (issue #30). Keyed by the tab's UUID rather than a
   /// `SidebarID` — terminal rows aren't selectable `List` rows, so they sit outside `hovered`.
@@ -53,6 +65,33 @@ struct ProjectSidebar: View {
     default:
       break
     }
+  }
+
+  /// The drag-to-split gesture for a root/workroom row (issue #101). Mirrors the tab-bar chip
+  /// (`WorkroomTabBar`), minus the reorder math: while dragging into the detail content it previews the
+  /// drop edge (driving the shared `paneDrag`), and on release over a pane it forms/extends the
+  /// workroom split via the same `insertWorkroomSplit` the chip uses. Attached with
+  /// `.simultaneousGesture` so it coexists with the List's vertical scroll; `minimumDistance` keeps a
+  /// plain click selecting the row (a zero-translation tap never starts the drag).
+  private func rowSplitDrag(_ id: SidebarID) -> some Gesture {
+    DragGesture(minimumDistance: 6, coordinateSpace: .global)
+      .onChanged { value in
+        paneDrag.wrappedValue = localize(value.location).map {
+          WorkroomPaneDrag(sid: id, location: $0)
+        }
+      }
+      .onEnded { value in
+        if let drop = dropTarget(value.location) {
+          store.insertWorkroomSplit(id, beside: drop.sid, edge: drop.edge)
+        }
+        paneDrag.wrappedValue = nil
+      }
+  }
+
+  /// Whether `id`'s row is the one currently being dragged into a split — drives a light dim cue
+  /// (the primary affordance is the detail-side accent drop band via `externalDrag`).
+  private func isDraggingForSplit(_ id: SidebarID) -> Bool {
+    paneDrag.wrappedValue?.sid == id
   }
 
   var body: some View {
@@ -287,7 +326,11 @@ struct ProjectSidebar: View {
         RowRunButton(target: target)
       }
     }.contentShape(Rectangle())
+      .opacity(isDraggingForSplit(id) ? 0.5 : 1)
       .onTapGesture { selectTarget(id) }
+      // Drag this root onto a displayed workroom pane to split them (issue #101). Simultaneous so the
+      // List still scrolls vertically; the tap above still selects.
+      .simultaneousGesture(rowSplitDrag(id))
       .help(style.tooltip)
       .accessibilityElement(children: .ignore)
       .accessibilityAddTraits(.isButton)
@@ -348,7 +391,11 @@ struct ProjectSidebar: View {
           .accessibilityIdentifier("sidebar.workroom.\(workroom.name).run")
       }
     }.contentShape(Rectangle())
+      .opacity(isDraggingForSplit(id) ? 0.5 : 1)
       .onTapGesture { selectTarget(id) }
+      // Drag this workroom onto a displayed pane to split them (issue #101). Simultaneous so the List
+      // still scrolls vertically; the tap above still selects.
+      .simultaneousGesture(rowSplitDrag(id))
       .accessibilityIdentifier("sidebar.workroom.\(workroom.name)")
       .accessibilityAddTraits(.isButton)
       .onHover { inside in

--- a/macapp/WorkroomApp/Views/RootView.swift
+++ b/macapp/WorkroomApp/Views/RootView.swift
@@ -121,8 +121,12 @@ struct RootView: View {
     } detail: {
       HStack(spacing: 0) {
         if store.sidebarVisible {
-          SidebarColumn()
-            .transition(.move(edge: .leading))
+          SidebarColumn(
+            paneDrag: $workroomChipDrag,
+            localize: { workroomChipLocal($0) },
+            dropTarget: { workroomChipDropTarget(at: $0) }
+          )
+          .transition(.move(edge: .leading))
         }
         detail
           .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -242,7 +246,10 @@ struct RootView: View {
       // so this large `body` stays within the type-checker's budget.
       .modifier(
         EdgeRevealSidebars(
-          sidebarVisible: store.sidebarVisible, inspectorVisible: showNotifications)
+          sidebarVisible: store.sidebarVisible, inspectorVisible: showNotifications,
+          paneDrag: $workroomChipDrag,
+          localize: { workroomChipLocal($0) },
+          dropTarget: { workroomChipDropTarget(at: $0) })
       )
       // Foreground toasts (issue #31): pinned bottom-right of the window, over the split + inspector.
       // Only ever populated while the inspector is closed, so it never overlaps the open inspector.

--- a/macapp/WorkroomApp/Views/SidebarColumn.swift
+++ b/macapp/WorkroomApp/Views/SidebarColumn.swift
@@ -13,6 +13,12 @@ import SwiftUI
 struct SidebarColumn: View {
   @EnvironmentObject var store: AppStore
 
+  /// Drag-to-split plumbing forwarded to `ProjectSidebar` so a row can be dragged into the detail to
+  /// form a workroom split (issue #101) — the same three the title-bar tab bar receives from `RootView`.
+  var paneDrag: Binding<WorkroomPaneDrag?> = .constant(nil)
+  var localize: (CGPoint) -> CGPoint? = { _ in nil }
+  var dropTarget: (CGPoint) -> (sid: SidebarID, edge: PaneEdge)? = { _ in nil }
+
   /// Live width while dragging — non-`nil` only during a drag. Local `@State` so each mouse-moved
   /// tick re-renders just this column, not the whole RootView tree. Committed once, on drag end.
   @State private var liveWidth: CGFloat?
@@ -27,7 +33,7 @@ struct SidebarColumn: View {
   }
 
   var body: some View {
-    ProjectSidebar()
+    ProjectSidebar(paneDrag: paneDrag, localize: localize, dropTarget: dropTarget)
       .frame(width: width)
       .frame(maxHeight: .infinity)
       // Tighten the gap to the detail panel: 2pt trailing vs the default 8 (mirrors the inspector's


### PR DESCRIPTION
Closes #101.

Let a **root or workroom be dragged straight from the projects sidebar** onto a displayed workroom pane to form (or extend) a workroom split — the same gesture that was previously only available by dragging a chip from the title-bar tab bar.

## Approach

This reuses the existing workroom-split engine **unchanged** — it's pure view wiring, no store/engine changes. The drag drives `RootView`'s `workroomChipDrag` state (so `WorkroomSplitView` renders the accent drop-edge preview) and releases into `AppStore.insertWorkroomSplit`, which already guards self-drops, `.project` leaves, and missing workrooms, and treats an already-open member as a *move*.

## Changes

- **`ProjectSidebar.swift`** — gains the same three drag params `RootView` already hands `WorkroomTabBar` (a `paneDrag` binding + `localize`/`dropTarget` closures). A `.simultaneousGesture` `DragGesture` on the root/workroom rows (not project rows) forms the split on drop; a light row dim cues the dragged row.
- **`SidebarColumn.swift`** + **`EdgeRevealSidebar.swift`** — thread those three params through both `ProjectSidebar` hosts, so drag-to-split works whether the sidebar is pinned or revealed-on-hover.
- **`RootView.swift`** — passes its existing `$workroomChipDrag` / `workroomChipLocal` / `workroomChipDropTarget` into both hosts.

### Why `.simultaneousGesture`

The sidebar is a vertical `List` backed by `NSTableView`, which would otherwise claim the drag and make it feel dead — a hazard already documented in `InspectorResizeHandle`/`PaneTreeView`. `.simultaneousGesture` lets the drag coexist with vertical scrolling, and `minimumDistance: 6` keeps a plain click selecting the row.

## Testing

The split engine (`insertWorkroomSplit`, move/collapse/dissolve, self-heal) is already covered by `WorkroomSplitTests`; this PR adds no new store behavior. Per that file's own convention, the drag gesture + renderer are **manual QA**:

- With ≥2 workrooms in a project, select one so its terminal shows, then drag another workroom (and the project root) from the sidebar onto the displayed pane — the accent edge band should preview the drop and releasing forms/extends the split on the chosen edge.
- A plain click still just selects; vertical list scrolling still works mid-list; dropping outside any pane or with nothing selected no-ops; dragging from the collapsed-sidebar edge-reveal panel also works.

> Note: the macOS toolchain wasn't available in the session environment, so `make app-build` / `make app-lint` were not run locally — verified manually for Swift correctness and 2-space/100-col style; CI will build and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiZQ9Yn83Sx8eQ8r2mo6kf)_