### PR TITLE
feat(macapp): file preview panel + shebang syntax detection

### DIFF
--- a/macapp/WorkroomApp/Core/AppStore.swift
+++ b/macapp/WorkroomApp/Core/AppStore.swift
@@ -137,6 +137,8 @@ final class AppStore: ObservableObject {
       scheduleSelectedStatusRefresh()
       // Swap the inspector to the newly-selected workroom's saved layout (issue #24).
       if selectedTargetID != oldValue { loadInspectorState() }
+      // The Files tree is re-pointed lazily by `FilesPanel` (only while that section is shown), not
+      // here — so selecting a workroom doesn't list its files unless you're actually browsing them.
     }
   }
   /// Project paths the user has collapsed in the sidebar (issue #14). Held here as `@Published`
@@ -242,6 +244,10 @@ final class AppStore: ObservableObject {
   @Published var changesSectionCollapsed = false {
     didSet { persistInspectorState() }
   }
+  /// Collapse state of the Files section (the repo file tree). Sits second, right under Changes.
+  @Published var filesSectionCollapsed = false {
+    didSet { persistInspectorState() }
+  }
   @Published var prSectionCollapsed = false {
     didSet { persistInspectorState() }
   }
@@ -264,7 +270,14 @@ final class AppStore: ObservableObject {
   /// `InspectorSectionKind.allCases`. Equal == the default three-equal-sections layout; updated when
   /// the user drags a divider (via `updateInspectorSizeWeights`) and persisted per workroom. Not set
   /// directly by the view — the `NSSplitView` reports drag results back through the store.
-  @Published var inspectorSizeWeights: [Double] = [1, 1, 1]
+  @Published var inspectorSizeWeights: [Double] = [1, 1, 1, 1]
+  /// The repo file tree behind the inspector's Files section. Re-pointed at the selected target's
+  /// directory whenever the selection changes (see `selectedTargetID.didSet`); the `FilesPanel`
+  /// observes it. Owned here so it survives inspector re-renders and tracks selection centrally.
+  let fileTree = FileTreeModel()
+  /// Shared in-file find state for the read-only file viewer (⌘F in a file pane). Only the focused
+  /// `PlainFileViewer` feeds + shows it; routed to from `startFindInFocusedPane`.
+  let fileFind = FileFindModel()
   /// True while `loadInspectorState` is writing the three collapse flags + weights, so their
   /// `didSet`s don't persist the values straight back (and the load isn't mistaken for a user edit).
   private var isLoadingInspectorState = false
@@ -2464,6 +2477,27 @@ final class AppStore: ObservableObject {
       for: target)
   }
 
+  /// Open a repo file as the selected target's single PREVIEW content tab (single-click in the Files
+  /// inspector section), read-only. Shares the preview slot with diffs. No-op if nothing's selected.
+  func openFilePreview(path: String) {
+    guard let target = selectedTarget else { return }
+    terminals.openFilePreview(FileDescriptor(path: path, isPreview: true), for: target)
+  }
+
+  /// Open a repo file as a *persisted* content tab (double-click in the Files section). No-op if
+  /// nothing's selected.
+  func openFilePersistent(path: String) {
+    guard let target = selectedTarget else { return }
+    terminals.openFilePersistent(FileDescriptor(path: path, isPreview: false), for: target)
+  }
+
+  /// Open a repo file in the configured external editor (⌘-click / context menu in the Files
+  /// section), reusing the shared editor path. No-op if nothing's selected.
+  func openFileInEditor(path: String) {
+    guard let target = selectedTarget else { return }
+    openWorkroomFile(relativePath: path, for: target)
+  }
+
   /// Open a workroom-relative file in the configured "Open file paths in" editor — the single path
   /// resolution shared by `openDiffTabFile` (#72) and `openChangedFileInEditor` (#93). Reuses
   /// `TerminalLinkOpener`, so it honours `Defaults[.filePathEditor]`; for a folder-capable editor CLI
@@ -2510,18 +2544,31 @@ final class AppStore: ObservableObject {
   func scrollFocusedTerminalToTop() { focusedSurface?.scrollToTop() }
   func scrollFocusedTerminalToBottom() { focusedSurface?.scrollToBottom() }
 
-  /// Open the scrollback find bar on the focused terminal (⌘F / Edit ▸ Find).
-  func startFindInFocusedTerminal() { focusedSurface?.startSearch() }
+  /// Open the find bar on the focused pane (⌘F / Edit ▸ Find): the terminal's scrollback search for a
+  /// terminal pane, the in-file find for a file pane. A diff pane has no find (no-op).
+  func startFindInFocusedPane() {
+    guard let target = selectedTarget, let tab = terminals.focusedTab(for: target) else { return }
+    switch tab.content {
+    case .terminal: focusedSurface?.startSearch()
+    case .file: fileFind.open()
+    case .diff: break
+    }
+  }
 
-  /// Navigate the focused terminal's *active* find to the next/previous match (⌘G / ⇧⌘G), wrapping
-  /// at the ends (the wrap is synthesized in `TerminalSearchModel.navigate` — the engine doesn't
-  /// wrap). Driven by the Edit ▸ Find Next/Previous menu key-equivalents; a no-op (returns `false`)
-  /// when no find bar is open. Still `@discardableResult` for the menu-button call site.
+  /// Navigate the focused pane's *active* find to the next/previous match (⌘G / ⇧⌘G), wrapping at the
+  /// ends. Tries the terminal search, then the in-file find. Returns `false` (so the key passes
+  /// through to the terminal) when neither is open. `@discardableResult` for the menu-button call site.
   @discardableResult
-  func navigateFocusedTerminalSearch(forward: Bool) -> Bool {
-    guard let surface = focusedSurface, surface.searchModel.isActive else { return false }
-    surface.searchModel.navigate(forward ? .next : .previous)
-    return true
+  func navigateFocusedPaneSearch(forward: Bool) -> Bool {
+    if let surface = focusedSurface, surface.searchModel.isActive {
+      surface.searchModel.navigate(forward ? .next : .previous)
+      return true
+    }
+    if fileFind.isOpen, fileFind.hasMatches {
+      forward ? fileFind.next() : fileFind.previous()
+      return true
+    }
+    return false
   }
 
   /// Split the focused pane by opening a new terminal beside it: ⌘D to the right, ⇧⌘D below
@@ -2854,12 +2901,17 @@ final class AppStore: ObservableObject {
     let state =
       Self.targetIDString(for: selectedTargetID)
       .flatMap { Defaults[.inspectorPaneStates][$0] } ?? .default
-    let collapsed = state.collapsed.count == 3 ? state.collapsed : [false, false, false]
-    let weights = state.weights.count == 3 ? state.weights : [1, 1, 1]
+    // One Files section was added (3 → 4): a pre-Files persisted layout (count 3) is discarded back
+    // to the all-expanded/equal default rather than mis-mapped onto the new ordering.
+    let count = InspectorSectionKind.allCases.count
+    let collapsed =
+      state.collapsed.count == count ? state.collapsed : Array(repeating: false, count: count)
+    let weights = state.weights.count == count ? state.weights : Array(repeating: 1.0, count: count)
     isLoadingInspectorState = true
     changesSectionCollapsed = collapsed[0]
-    prSectionCollapsed = collapsed[1]
-    notificationsSectionCollapsed = collapsed[2]
+    filesSectionCollapsed = collapsed[1]
+    prSectionCollapsed = collapsed[2]
+    notificationsSectionCollapsed = collapsed[3]
     inspectorSizeWeights = weights
     isLoadingInspectorState = false
   }
@@ -2871,14 +2923,18 @@ final class AppStore: ObservableObject {
       return
     }
     Defaults[.inspectorPaneStates][key] = InspectorPaneState(
-      collapsed: [changesSectionCollapsed, prSectionCollapsed, notificationsSectionCollapsed],
+      collapsed: [
+        changesSectionCollapsed, filesSectionCollapsed, prSectionCollapsed,
+        notificationsSectionCollapsed,
+      ],
       weights: inspectorSizeWeights)
   }
 
   /// Record new pane weights reported by the inspector's `NSSplitView` after a divider drag, and
   /// persist them for the selected workroom.
   func updateInspectorSizeWeights(_ weights: [Double]) {
-    guard weights.count == 3, weights != inspectorSizeWeights else { return }
+    guard weights.count == InspectorSectionKind.allCases.count, weights != inspectorSizeWeights
+    else { return }
     inspectorSizeWeights = weights
     persistInspectorState()
   }

--- a/macapp/WorkroomApp/Core/DefaultsKeys.swift
+++ b/macapp/WorkroomApp/Core/DefaultsKeys.swift
@@ -124,14 +124,14 @@ extension Defaults.Keys {
 }
 
 /// One workroom's persisted inspector layout: the collapse state and relative pane heights of the
-/// three sections, ordered as `InspectorSectionKind.allCases` (Changes, Pull Request,
+/// sections, ordered as `InspectorSectionKind.allCases` (Changes, Files, Pull Request,
 /// Notifications). `weights` are relative (renormalised among the expanded panes at layout time),
-/// so they survive inspector-width/height changes; equal weights == the three-equal-sections
-/// default.
+/// so they survive inspector-width/height changes; equal weights == the equal-sections default. A
+/// layout saved before the Files section existed (3 entries) is discarded to this default on load.
 struct InspectorPaneState: Codable, Defaults.Serializable, Equatable {
   var collapsed: [Bool]
   var weights: [Double]
 
   static let `default` = InspectorPaneState(
-    collapsed: [false, false, false], weights: [1, 1, 1])
+    collapsed: [false, false, false, false], weights: [1, 1, 1, 1])
 }

--- a/macapp/WorkroomApp/Core/FileFind.swift
+++ b/macapp/WorkroomApp/Core/FileFind.swift
@@ -1,0 +1,117 @@
+import Combine
+import Foundation
+
+/// In-file **Find** for the read-only `PlainFileViewer`. Unlike the terminal find (which libghostty
+/// owns), the file viewer is our own SwiftUI view, so we search it ourselves: the pure case-insensitive
+/// matcher here (`FileFind.matches`, unit-tested) plus a small observable model the focused viewer
+/// feeds its lines into and the find bar drives. Only the focused file pane uses the (shared) model —
+/// see `FileFindModel`.
+
+/// One match: a 0-based line index and the character-offset range of the hit within that line.
+struct FileFindMatch: Equatable {
+  let line: Int
+  let range: Range<Int>
+}
+
+enum FileFind {
+  /// Cap on total matches, so a one-character needle in a huge file can't produce an unbounded list
+  /// (and the per-keystroke re-search stays cheap). Beyond this the extra hits simply aren't tracked.
+  static let matchCap = 5000
+
+  /// Every case-insensitive match of `needle` across `lines`, in document order (top to bottom,
+  /// left to right). An empty needle yields no matches. Pure — unit-tested without a view.
+  static func matches(in lines: [String], needle: String) -> [FileFindMatch] {
+    guard !needle.isEmpty else { return [] }
+    var result: [FileFindMatch] = []
+    for (index, line) in lines.enumerated() {
+      var searchStart = line.startIndex
+      while searchStart < line.endIndex,
+        let hit = line.range(
+          of: needle, options: .caseInsensitive, range: searchStart..<line.endIndex)
+      {
+        let lo = line.distance(from: line.startIndex, to: hit.lowerBound)
+        let hi = line.distance(from: line.startIndex, to: hit.upperBound)
+        result.append(FileFindMatch(line: index, range: lo..<hi))
+        if result.count >= matchCap { return result }
+        // Advance past this hit; guard against a zero-width range (shouldn't happen for a non-empty
+        // needle, but keeps the loop strictly progressing).
+        searchStart =
+          hit.upperBound > hit.lowerBound ? hit.upperBound : line.index(after: hit.lowerBound)
+      }
+    }
+    return result
+  }
+}
+
+/// Observable state for the file find bar. The focused `PlainFileViewer` feeds its lines via
+/// `setSource`; the bar binds `needle` and reads `matches`/`current`; the viewer reads the same to
+/// highlight hits and scroll the current one into view. One shared instance (only the focused file
+/// pane searches), owned by `AppStore`.
+@MainActor
+final class FileFindModel: ObservableObject {
+  @Published private(set) var isOpen = false
+  @Published private(set) var needle = ""
+  @Published private(set) var matches: [FileFindMatch] = []
+  /// Index into `matches` of the highlighted hit (0-based); 0 when there are none.
+  @Published private(set) var current = 0
+
+  private var lines: [String] = []
+
+  /// Point the model at the focused viewer's content and re-search with the current needle. Called
+  /// when the focused file changes (or its content loads).
+  func setSource(_ lines: [String]) {
+    self.lines = lines
+    recompute(resetCurrent: true)
+  }
+
+  func open() { isOpen = true }
+
+  func close() {
+    isOpen = false
+    needle = ""
+    matches = []
+    current = 0
+  }
+
+  /// Set the search text (from the bar's field) and re-search.
+  func setNeedle(_ text: String) {
+    needle = text
+    recompute(resetCurrent: true)
+  }
+
+  func next() {
+    guard !matches.isEmpty else { return }
+    current = (current + 1) % matches.count
+  }
+
+  func previous() {
+    guard !matches.isEmpty else { return }
+    current = (current - 1 + matches.count) % matches.count
+  }
+
+  private func recompute(resetCurrent: Bool) {
+    matches = FileFind.matches(in: lines, needle: needle)
+    current = resetCurrent ? 0 : min(current, max(0, matches.count - 1))
+  }
+
+  var currentMatch: FileFindMatch? { matches.indices.contains(current) ? matches[current] : nil }
+
+  var hasMatches: Bool { !matches.isEmpty }
+
+  /// "3/12", "No results", or "" while the field is empty.
+  var summary: String {
+    if needle.isEmpty { return "" }
+    return matches.isEmpty ? "No results" : "\(current + 1)/\(matches.count)"
+  }
+
+  /// The hits on a given line with whether each is the current one — for the viewer's per-line
+  /// highlighting. Empty for lines with no hits (the common case), so most rows do no work.
+  func highlights(onLine line: Int) -> [(range: Range<Int>, isCurrent: Bool)] {
+    guard isOpen, !matches.isEmpty else { return [] }
+    var out: [(range: Range<Int>, isCurrent: Bool)] = []
+    for (offset, match) in matches.enumerated() where match.line == line {
+      out.append((match.range, offset == current))
+    }
+    return out
+  }
+}

--- a/macapp/WorkroomApp/Core/FileTree.swift
+++ b/macapp/WorkroomApp/Core/FileTree.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// File tree for the inspector's **Files** section: list the selected repo's working tree (honoring
+/// VCS ignores), show it as a collapsible tree, and open a file read-only in the main pane. This
+/// file is the pure, engine-free core — VCS command construction + output parsing, the flat-list →
+/// tree builder, and the tree → visible-rows flattener — all unit-tested without shelling out or a
+/// view (`FileTreeTests`). The live data source (`FileTreeModel`) and the SwiftUI panel
+/// (`FilesPanel`) build on these.
+
+// MARK: - Content-tab payload
+
+/// The `.file` payload of a content tab: a repo-relative file shown read-only in the main pane.
+/// Sibling of `DiffDescriptor` — a value type, so retargeting the preview mutates a copy in place
+/// and reassigns it, keeping the tab's id (and thus its strip slot / split position) stable.
+struct FileDescriptor: Equatable, Hashable, Sendable {
+  /// Repo-relative path (resolved against the workroom directory).
+  var path: String
+  /// True while this is the target's single preview tab (italic chip, replaced by the next preview);
+  /// false once persisted ("Keep Open" / double-click / opened persistently).
+  var isPreview: Bool
+
+  /// Two descriptors address the *same* file tab when they point at the same path — the identity used
+  /// to dedupe (re-select an already-open file) and to retarget the preview. The preview flag is
+  /// deliberately excluded, mirroring `DiffDescriptor.sameFile`.
+  func sameFile(as other: FileDescriptor) -> Bool { path == other.path }
+}
+
+// MARK: - Tree model (pure)
+
+/// A node in the repo file tree: a directory (with sorted children) or a file leaf. Built by
+/// `FileTreeBuilder`; `children == nil` marks a file leaf (vs. `[]` — an empty directory, which a
+/// flat file listing never produces but the type still distinguishes).
+struct FileNode: Identifiable, Equatable, Sendable {
+  /// The last path component (display name).
+  let name: String
+  /// The repo-relative path (`"src/app/main.swift"`) — also the stable identity.
+  let path: String
+  let isDirectory: Bool
+  /// Sorted children (directories first, then files; each group alpha, case-insensitive). `nil` for
+  /// a file leaf.
+  let children: [FileNode]?
+
+  var id: String { path }
+}
+
+/// One visible row of the tree: a node plus its indent depth. Produced by flattening the tree
+/// against the set of expanded directory paths — the Files panel renders these as an indented list
+/// (it lives inside the inspector's own scroll view, so it can't host a `List`/`OutlineGroup`).
+struct FileTreeRow: Equatable {
+  let node: FileNode
+  let depth: Int
+}
+
+/// Pure builders for the Files panel: a flat list of repo-relative paths → a sorted `FileNode` tree,
+/// and a tree + expansion set → the visible rows. No I/O, no view — unit-tested directly.
+enum FileTreeBuilder {
+  /// Build the sorted tree from a flat list of repo-relative file paths (as `git ls-files` / `jj file
+  /// list` emit them). Intermediate directories are synthesised; duplicates collapse; each level is
+  /// sorted directories-first then alpha (case-insensitive). Empty / `.`-only components are skipped.
+  static func build(from relativePaths: [String]) -> [FileNode] {
+    let root = MutableNode(name: "", path: "")
+    for raw in relativePaths {
+      let components = raw.split(separator: "/").map(String.init).filter {
+        $0 != "." && !$0.isEmpty
+      }
+      guard !components.isEmpty else { continue }
+      var node = root
+      var accumulated = ""
+      for (index, component) in components.enumerated() {
+        accumulated = accumulated.isEmpty ? component : accumulated + "/" + component
+        let isLeaf = index == components.count - 1
+        if let existing = node.children[component] {
+          // A path already seen as a directory prefix wins over a later "leaf" claim (can't really
+          // happen from a flat file list, but keep directories sticky).
+          node = existing
+        } else {
+          let child = MutableNode(name: component, path: accumulated, isFileLeaf: isLeaf)
+          node.children[component] = child
+          node = child
+        }
+      }
+    }
+    return root.sortedChildren()
+  }
+
+  /// Flatten the tree into the rows currently visible, given which directory paths are expanded.
+  /// A collapsed directory contributes its own row but none of its descendants.
+  static func flatten(_ roots: [FileNode], expanded: Set<String>, depth: Int = 0) -> [FileTreeRow] {
+    var rows: [FileTreeRow] = []
+    for node in roots {
+      rows.append(FileTreeRow(node: node, depth: depth))
+      if node.isDirectory, expanded.contains(node.path), let children = node.children {
+        rows.append(contentsOf: flatten(children, expanded: expanded, depth: depth + 1))
+      }
+    }
+    return rows
+  }
+
+  /// Mutable scratch node used only while building; converted to the immutable `FileNode` tree.
+  private final class MutableNode {
+    let name: String
+    let path: String
+    /// Starts as a file leaf only if created for the last component; gains children → becomes a dir.
+    private var isFileLeaf: Bool
+    var children: [String: MutableNode] = [:]
+
+    init(name: String, path: String, isFileLeaf: Bool = false) {
+      self.name = name
+      self.path = path
+      self.isFileLeaf = isFileLeaf
+    }
+
+    /// A node with children is a directory regardless of how it was first created.
+    private var isDirectory: Bool { !children.isEmpty || !isFileLeaf }
+
+    func sortedChildren() -> [FileNode] {
+      children.values
+        .map { child -> FileNode in
+          let dir = child.isDirectory
+          return FileNode(
+            name: child.name, path: child.path, isDirectory: dir,
+            children: dir ? child.sortedChildren() : nil)
+        }
+        .sorted(by: FileTreeBuilder.order)
+    }
+  }
+
+  /// Directories before files; within a group, case-insensitive alphabetical, ties broken by the
+  /// exact name so the order is total (stable across runs).
+  private static func order(_ a: FileNode, _ b: FileNode) -> Bool {
+    if a.isDirectory != b.isDirectory { return a.isDirectory }
+    let byName = a.name.localizedCaseInsensitiveCompare(b.name)
+    return byName == .orderedSame ? a.name < b.name : byName == .orderedAscending
+  }
+}
+
+// MARK: - VCS listing (pure)
+
+/// Which VCS lists the working tree. The Files panel probes git first (covers git worktrees and
+/// colocated jj repos), then jj (a non-colocated jj workspace has no `.git` of its own).
+enum FileListVCS: Equatable, Sendable {
+  case git
+  case jj
+}
+
+/// Pure command construction + output parsing for the working-tree listing, so the args and the
+/// path-cleanup are unit-tested without spawning git/jj.
+enum FileListing {
+  /// The executable + args that list the working tree honoring ignore rules.
+  /// - git: tracked + untracked-but-not-ignored, NUL-separated (`-z`) so odd filenames survive.
+  /// - jj: the working-copy files (jj auto-tracks, so this reflects new files too).
+  static func command(_ vcs: FileListVCS) -> (executable: String, args: [String]) {
+    switch vcs {
+    case .git: return ("git", ["ls-files", "--cached", "--others", "--exclude-standard", "-z"])
+    case .jj: return ("jj", ["file", "list"])
+    }
+  }
+
+  /// Parse a listing command's stdout into clean repo-relative paths. git output is NUL-separated
+  /// (never split on newlines — a filename may legitimately contain spaces or a newline, which is
+  /// exactly why `-z` is used); jj output is newline-separated (split on any newline — `\n`, `\r\n`,
+  /// or `\r` — via `isNewline`, since Swift treats `\r\n` as a *single* Character that a literal
+  /// `"\n"` split would miss). Empties and a leading `./` are dropped.
+  static func parse(_ stdout: String, vcs: FileListVCS) -> [String] {
+    let raw: [Substring]
+    switch vcs {
+    case .git:
+      raw = stdout.split(separator: "\0", omittingEmptySubsequences: true)
+    case .jj:
+      raw = stdout.split(omittingEmptySubsequences: true, whereSeparator: \.isNewline)
+    }
+    return
+      raw
+      .map(String.init)
+      .filter { !$0.isEmpty }
+      .map { $0.hasPrefix("./") ? String($0.dropFirst(2)) : $0 }
+  }
+}

--- a/macapp/WorkroomApp/Core/FileTreeModel.swift
+++ b/macapp/WorkroomApp/Core/FileTreeModel.swift
@@ -1,0 +1,129 @@
+import Combine
+import Foundation
+
+/// The live data source behind the inspector's **Files** section: lists the selected target's
+/// working tree (via git, falling back to jj), builds the tree, tracks which directories are
+/// expanded, and reloads when the filesystem changes. All the data-shaping is delegated to the pure
+/// helpers in `FileTree.swift`; this owns the I/O + observable state.
+///
+/// `@MainActor` so SwiftUI reads it directly; the listing itself runs off-main inside
+/// `StatusCommandRunner` (it drains the child's pipes on background queues), so the main actor only
+/// touches the small parsed result.
+@MainActor
+final class FileTreeModel: ObservableObject {
+  enum State: Equatable {
+    /// No target selected.
+    case idle
+    /// Listing for the first time (no tree yet to show).
+    case loading
+    /// `roots` is current (may be empty — an empty repo).
+    case loaded
+    /// Not a git/jj repo, or the tool is missing — nothing to list.
+    case unavailable
+  }
+
+  /// The sorted root nodes of the current target's tree.
+  @Published private(set) var roots: [FileNode] = []
+  @Published private(set) var state: State = .idle
+  /// Expanded directory paths. Reset on target switch; the panel toggles entries.
+  @Published var expanded: Set<String> = []
+
+  /// Max rows the panel renders at once (a guard for pathologically large trees); the panel notes
+  /// any overflow rather than silently truncating.
+  static let renderCap = 4000
+
+  /// The visible rows for the current tree + expansion — what the panel iterates.
+  var rows: [FileTreeRow] { FileTreeBuilder.flatten(roots, expanded: expanded) }
+
+  private var currentPath: String?
+  private let runner: StatusCommandRunning
+  private var watcher: WorkroomFileWatcher?
+  private var loadTask: Task<Void, Never>?
+
+  init(runner: StatusCommandRunning = StatusCommandRunner()) {
+    self.runner = runner
+  }
+
+  deinit {
+    loadTask?.cancel()
+    watcher?.stop()
+  }
+
+  /// Point the model at a target directory (a workroom/project root), or `nil` to clear. Starts
+  /// watching it and lists it. No-op if already on this path (so re-renders don't re-list).
+  func activate(path: String?) {
+    guard path != currentPath else { return }
+    loadTask?.cancel()
+    currentPath = path
+    expanded = []
+    // A nil path (nothing selected / Files section hidden) or a missing directory (a vanished
+    // workroom) clears the tree without spawning git/jj or a watcher.
+    var isDir: ObjCBool = false
+    let exists =
+      path.map { FileManager.default.fileExists(atPath: $0, isDirectory: &isDir) } ?? false
+    guard let path, exists, isDir.boolValue else {
+      watcher?.stop()
+      watcher = nil
+      roots = []
+      state = path == nil ? .idle : .unavailable
+      return
+    }
+    startWatching(path)
+    state = .loading
+    roots = []
+    reload()
+  }
+
+  /// Re-list the current target (a manual refresh, or after a watched filesystem change). Keeps the
+  /// existing tree visible while the new listing runs.
+  func reload() {
+    guard let path = currentPath else { return }
+    loadTask?.cancel()
+    loadTask = Task { [weak self] in
+      guard let self else { return }
+      let paths = await FileTreeModel.list(path: path, runner: self.runner)
+      guard !Task.isCancelled, self.currentPath == path else { return }
+      if let paths {
+        self.roots = FileTreeBuilder.build(from: paths)
+        self.state = .loaded
+      } else {
+        self.roots = []
+        self.state = .unavailable
+      }
+    }
+  }
+
+  /// Expand/collapse a directory row. No-op for files.
+  func toggle(_ node: FileNode) {
+    guard node.isDirectory else { return }
+    if expanded.contains(node.path) {
+      expanded.remove(node.path)
+    } else {
+      expanded.insert(node.path)
+    }
+  }
+
+  private func startWatching(_ path: String) {
+    let watcher = WorkroomFileWatcher(latency: 1.0) { [weak self] changed in
+      // Ignore pure VCS-internal churn (a jj snapshot under `.jj/`, git writing `.git/`) so the tree
+      // doesn't self-trigger an endless reload; any real working-tree edit still refreshes it.
+      let relevant = changed.contains { !$0.contains("/.git/") && !$0.contains("/.jj/") }
+      if relevant { self?.reload() }
+    }
+    watcher.start(path: path)
+    self.watcher = watcher
+  }
+
+  /// List the working tree at `path`: try git first (covers git worktrees and colocated jj repos),
+  /// then jj (a non-colocated jj workspace has no `.git`). Returns the parsed repo-relative paths, or
+  /// `nil` when neither tool yields a listing (not a repo / tool missing). Static + injectable runner
+  /// so the git→jj fallthrough is testable.
+  static func list(path: String, runner: StatusCommandRunning) async -> [String]? {
+    for vcs in [FileListVCS.git, .jj] {
+      let command = FileListing.command(vcs)
+      let result = await runner.run(command.executable, command.args, in: path, timeout: 10)
+      if result.ok { return FileListing.parse(result.stdout, vcs: vcs) }
+    }
+    return nil
+  }
+}

--- a/macapp/WorkroomApp/Core/InspectorPanePolicy.swift
+++ b/macapp/WorkroomApp/Core/InspectorPanePolicy.swift
@@ -1,9 +1,10 @@
 import AppKit
 
-/// Which inspector section a pane hosts. Mirrors the three `RightInspector` sections, top to
-/// bottom: Changes, Pull Request, Notifications. Used for ordering and the section count.
+/// Which inspector section a pane hosts. Mirrors the `RightInspector` sections, top to bottom:
+/// Changes, Files, Pull Request, Notifications. Used for ordering and the section count.
 enum InspectorSectionKind: CaseIterable {
   case changes
+  case files
   case pullRequest
   case notifications
 }

--- a/macapp/WorkroomApp/Core/SyntaxHighlighting/FileHighlightMapper.swift
+++ b/macapp/WorkroomApp/Core/SyntaxHighlighting/FileHighlightMapper.swift
@@ -1,0 +1,133 @@
+import AppKit
+import SwiftUI
+
+/// Maps whole-file highlight spans onto a file's lines, producing one coloured `AttributedString`
+/// per line (0-based, line order). Pure (no I/O, no parse) — the byte↔line arithmetic mirrors
+/// `DiffHighlightMapper`, but without a diff: every line is the theme foreground with captured spans
+/// recoloured. Used by the read-only `PlainFileViewer`; unit-tested without a parser or UI.
+enum FileHighlightMapper {
+  /// Build one `AttributedString` per file line from `spans` over the whole-file `content`.
+  /// Uncaptured text uses the theme foreground; captured spans use the syntax colour. A trailing
+  /// newline does not add a phantom empty final line. Returns `[]` for empty content.
+  static func attributedLines(content: String, spans: [HighlightSpan], tokens: ThemeTokens)
+    -> [AttributedString]
+  {
+    let bytes = Array(content.utf8)
+    guard !bytes.isEmpty else { return [] }
+
+    // Line byte ranges. `lineEnd` excludes the trailing `\n` (a `\r` before it stays in the line).
+    var lineStart: [Int] = [0]
+    var lineEnd: [Int] = []
+    for (i, b) in bytes.enumerated() where b == 0x0A {
+      lineEnd.append(i)
+      lineStart.append(i + 1)
+    }
+    lineEnd.append(bytes.count)
+    // Content ending in `\n` yields a trailing empty line range — drop it so we don't render a blank
+    // final row (the line count then matches what an editor shows).
+    let lineCount =
+      (lineStart.count > 1 && lineStart[lineStart.count - 1] == bytes.count)
+      ? lineStart.count - 1 : lineStart.count
+
+    // The line index containing byte offset `b` (largest i with lineStart[i] <= b).
+    func lineIndex(forByte b: Int) -> Int {
+      var lo = 0
+      var hi = lineCount - 1
+      var ans = 0
+      while lo <= hi {
+        let mid = (lo + hi) / 2
+        if lineStart[mid] <= b {
+          ans = mid
+          lo = mid + 1
+        } else {
+          hi = mid - 1
+        }
+      }
+      return ans
+    }
+
+    // Bucket spans per line, splitting a multiline span (block comment, multiline string) across the
+    // lines it covers. Input spans are ascending + non-overlapping, so each bucket stays ascending.
+    var buckets: [[HighlightSpan]] = Array(repeating: [], count: lineCount)
+    for span in spans {
+      let lo = span.byteRange.lowerBound
+      let hi = min(span.byteRange.upperBound, bytes.count)
+      guard lo < hi else { continue }
+      let first = lineIndex(forByte: lo)
+      let last = lineIndex(forByte: hi - 1)
+      guard first < lineCount else { continue }
+      for l in first...min(last, lineCount - 1) {
+        let s = max(lo, lineStart[l])
+        let e = min(hi, lineEnd[l])
+        if s < e { buckets[l].append(HighlightSpan(byteRange: s..<e, capture: span.capture)) }
+      }
+    }
+
+    let defaultColor = Color(nsColor: tokens.nsFg)
+    var result: [AttributedString] = []
+    result.reserveCapacity(lineCount)
+
+    for idx in 0..<lineCount {
+      var attr = AttributedString()
+      var cursor = lineStart[idx]
+
+      func emit(_ range: Range<Int>, _ color: Color) {
+        guard range.lowerBound < range.upperBound else { return }
+        var run = AttributedString(String(decoding: bytes[range], as: UTF8.self))
+        run.foregroundColor = color
+        attr.append(run)
+      }
+
+      for span in buckets[idx] {
+        if span.byteRange.lowerBound > cursor {
+          emit(cursor..<span.byteRange.lowerBound, defaultColor)
+        }
+        let color = tokens.syntaxColor(forCapture: span.capture) ?? defaultColor
+        emit(max(span.byteRange.lowerBound, cursor)..<span.byteRange.upperBound, color)
+        cursor = max(cursor, span.byteRange.upperBound)
+      }
+      if cursor < lineEnd[idx] { emit(cursor..<lineEnd[idx], defaultColor) }
+      result.append(attr)
+    }
+    return result
+  }
+
+  /// Build a single themed `NSAttributedString` for the whole file — the text the `NSTextView`-backed
+  /// `CodeTextView` renders (SwiftUI `Text` can't select across lines). Every character starts in the
+  /// theme foreground + `font`; captured spans are recoloured. `spans == []` yields a plain (but still
+  /// monospaced + themed) string. Spans are UTF-8 byte ranges (tree-sitter), converted to the
+  /// `NSAttributedString`'s UTF-16 ranges via one forward walk (spans are ascending + non-overlapping,
+  /// so the cursor only moves forward).
+  static func nsAttributedString(
+    content: String, spans: [HighlightSpan], tokens: ThemeTokens, font: NSFont
+  ) -> NSAttributedString {
+    let result = NSMutableAttributedString(string: content)
+    let full = NSRange(location: 0, length: result.length)
+    result.addAttribute(.font, value: font, range: full)
+    result.addAttribute(.foregroundColor, value: tokens.nsFg, range: full)
+    guard !spans.isEmpty else { return result }
+
+    let byteCount = content.utf8.count
+    var index = content.startIndex
+    var byte = 0
+    for span in spans {
+      let lo = span.byteRange.lowerBound
+      let hi = min(span.byteRange.upperBound, byteCount)
+      guard lo < hi, lo >= byte else { continue }
+      while byte < lo, index < content.endIndex {
+        byte += content[index].utf8.count
+        index = content.index(after: index)
+      }
+      let start = index
+      while byte < hi, index < content.endIndex {
+        byte += content[index].utf8.count
+        index = content.index(after: index)
+      }
+      guard start < index else { continue }
+      let color = tokens.syntaxColor(forCapture: span.capture).map { NSColor($0) } ?? tokens.nsFg
+      result.addAttribute(
+        .foregroundColor, value: color, range: NSRange(start..<index, in: content))
+    }
+    return result
+  }
+}

--- a/macapp/WorkroomApp/Core/SyntaxHighlighting/MarkdownRenderer.swift
+++ b/macapp/WorkroomApp/Core/SyntaxHighlighting/MarkdownRenderer.swift
@@ -1,0 +1,172 @@
+import AppKit
+import Foundation
+
+/// Renders Markdown source into a styled `NSAttributedString` for the file viewer's preview mode,
+/// using Foundation's `AttributedString(markdown:)` (full block syntax) — no third-party dependency.
+/// Walks the parsed document block-by-block (`presentationIntent`) applying heading sizes, list
+/// bullets/indents, code blocks, block quotes, thematic breaks, and inline emphasis/code/links/strike.
+/// Covers READMEs and plan docs; tables and images are not rendered (the inline text is kept).
+enum MarkdownRenderer {
+  static let baseSize: CGFloat = 13.5
+
+  static func attributedString(_ markdown: String, tokens: ThemeTokens) -> NSAttributedString {
+    let options = AttributedString.MarkdownParsingOptions(
+      allowsExtendedAttributes: true,
+      interpretedSyntax: .full,
+      failurePolicy: .returnPartiallyParsedIfPossible)
+    guard let doc = try? AttributedString(markdown: markdown, options: options) else {
+      return NSAttributedString(
+        string: markdown,
+        attributes: [.font: NSFont.systemFont(ofSize: baseSize), .foregroundColor: tokens.nsFg])
+    }
+
+    let out = NSMutableAttributedString()
+    var firstBlock = true
+
+    for (intent, range) in doc.runs[\.presentationIntent] {
+      let info = blockInfo(intent)
+      if !firstBlock { out.append(NSAttributedString(string: "\n")) }
+      firstBlock = false
+
+      if info.isThematicBreak {
+        out.append(thematicBreak(tokens: tokens))
+        continue
+      }
+
+      let paragraph = paragraphStyle(for: info)
+      let headingSize = info.headerLevel.map(headerSize) ?? baseSize
+
+      // List bullet / ordinal marker.
+      if info.listDepth > 0, let ordinal = info.listItemOrdinal {
+        let marker = info.isOrderedList ? "\(ordinal). " : "•  "
+        out.append(
+          NSAttributedString(
+            string: marker,
+            attributes: [
+              .font: font(size: baseSize, bold: false, italic: false, monospace: false),
+              .foregroundColor: NSColor(tokens.fgMuted), .paragraphStyle: paragraph,
+            ]))
+      }
+
+      // Inline runs within the block.
+      let blockSlice = doc[range]
+      for run in blockSlice.runs {
+        let text = String(blockSlice[run.range].characters)
+        guard !text.isEmpty else { continue }
+        let inline = run.inlinePresentationIntent ?? []
+        let isCode = info.isCodeBlock || inline.contains(.code)
+        let bold = info.headerLevel != nil || inline.contains(.stronglyEmphasized)
+        let italic = inline.contains(.emphasized)
+        let size = (isCode && !info.isCodeBlock) ? baseSize - 0.5 : headingSize
+
+        var attrs: [NSAttributedString.Key: Any] = [
+          .paragraphStyle: paragraph,
+          .font: font(size: size, bold: bold, italic: italic, monospace: isCode),
+          .foregroundColor: info.isBlockQuote ? NSColor(tokens.fgMuted) : tokens.nsFg,
+        ]
+        if isCode {
+          attrs[.backgroundColor] = NSColor(tokens.fgMuted).withAlphaComponent(0.12)
+        }
+        if inline.contains(.strikethrough) {
+          attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+        }
+        if let link = run.link {
+          attrs[.foregroundColor] = NSColor(tokens.accent)
+          attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue
+          attrs[.link] = link
+        }
+        out.append(NSAttributedString(string: text, attributes: attrs))
+      }
+    }
+    return out
+  }
+
+  // MARK: Block classification
+
+  private struct BlockInfo {
+    var headerLevel: Int?
+    var isCodeBlock = false
+    var isBlockQuote = false
+    var isThematicBreak = false
+    var listItemOrdinal: Int?
+    var isOrderedList = false
+    var listDepth = 0
+  }
+
+  private static func blockInfo(_ intent: PresentationIntent?) -> BlockInfo {
+    var info = BlockInfo()
+    guard let intent else { return info }
+    for component in intent.components {
+      switch component.kind {
+      case .header(let level): info.headerLevel = level
+      case .codeBlock: info.isCodeBlock = true
+      case .blockQuote: info.isBlockQuote = true
+      case .thematicBreak: info.isThematicBreak = true
+      case .listItem(let ordinal): info.listItemOrdinal = ordinal
+      case .orderedList:
+        info.isOrderedList = true
+        info.listDepth += 1
+      case .unorderedList:
+        info.listDepth += 1
+      default: break
+      }
+    }
+    return info
+  }
+
+  // MARK: Styling
+
+  private static func headerSize(_ level: Int) -> CGFloat {
+    switch level {
+    case 1: return 26
+    case 2: return 21
+    case 3: return 17
+    case 4: return 15
+    case 5: return 14
+    default: return baseSize
+    }
+  }
+
+  private static func paragraphStyle(for info: BlockInfo) -> NSParagraphStyle {
+    let p = NSMutableParagraphStyle()
+    p.lineSpacing = 2
+    p.paragraphSpacing = info.headerLevel != nil ? 6 : 9
+    if info.headerLevel != nil { p.paragraphSpacingBefore = 10 }
+    if info.listDepth > 0 {
+      let indent = CGFloat(info.listDepth) * 22
+      p.headIndent = indent
+      p.firstLineHeadIndent = indent - 18
+      p.paragraphSpacing = 3
+    }
+    if info.isBlockQuote {
+      p.headIndent += 18
+      p.firstLineHeadIndent += 18
+    }
+    return p
+  }
+
+  private static func font(size: CGFloat, bold: Bool, italic: Bool, monospace: Bool) -> NSFont {
+    if monospace {
+      let base = NSFont.monospacedSystemFont(ofSize: size, weight: bold ? .semibold : .regular)
+      return italic ? NSFontManager.shared.convert(base, toHaveTrait: .italicFontMask) : base
+    }
+    var traits: NSFontDescriptor.SymbolicTraits = []
+    if bold { traits.insert(.bold) }
+    if italic { traits.insert(.italic) }
+    let descriptor = NSFont.systemFont(ofSize: size).fontDescriptor.withSymbolicTraits(traits)
+    return NSFont(descriptor: descriptor, size: size) ?? NSFont.systemFont(ofSize: size)
+  }
+
+  private static func thematicBreak(tokens: ThemeTokens) -> NSAttributedString {
+    let p = NSMutableParagraphStyle()
+    p.paragraphSpacingBefore = 6
+    p.paragraphSpacing = 6
+    return NSAttributedString(
+      string: String(repeating: "─", count: 40),
+      attributes: [
+        .font: NSFont.systemFont(ofSize: baseSize),
+        .foregroundColor: NSColor(tokens.fgMuted).withAlphaComponent(0.4),
+        .paragraphStyle: p,
+      ])
+  }
+}

--- a/macapp/WorkroomApp/Core/SyntaxHighlighting/SyntaxGrammar.swift
+++ b/macapp/WorkroomApp/Core/SyntaxHighlighting/SyntaxGrammar.swift
@@ -127,6 +127,39 @@ enum SyntaxLanguage {
     return nil
   }
 
+  /// Grammar for a file, trying the path first (extension / known filename), then the **shebang** on
+  /// the first line for an extension-less script (`#!/bin/bash`, `#!/usr/bin/env python3`). `nil` ⇒
+  /// render plain. Used by the file viewer, which has the content to sniff.
+  static func grammar(forPath path: String, firstLine: String?) -> GrammarID? {
+    if let g = grammar(forPath: path) { return g }
+    if let firstLine, let g = grammar(forShebang: firstLine) { return g }
+    return nil
+  }
+
+  /// Map a shebang line to a grammar. Resolves the interpreter basename — unwrapping
+  /// `/usr/bin/env [flags] <interp>` — and strips a version suffix (`python3.11` → python). Returns
+  /// `nil` for a non-shebang line or an unknown interpreter. Pure + unit-tested.
+  static func grammar(forShebang line: String) -> GrammarID? {
+    guard line.hasPrefix("#!") else { return nil }
+    let tokens = line.dropFirst(2).split(whereSeparator: { $0 == " " || $0 == "\t" }).map(
+      String.init)
+    guard var interpreter = tokens.first.map({ ($0 as NSString).lastPathComponent }) else {
+      return nil
+    }
+    // `env` defers to the first non-flag argument (its `-S`/`-i`… options are skipped).
+    if interpreter == "env" {
+      guard let next = tokens.dropFirst().first(where: { !$0.hasPrefix("-") }) else { return nil }
+      interpreter = (next as NSString).lastPathComponent
+    }
+    // Trim any trailing CR (a CRLF first line) / whitespace before matching.
+    let name = interpreter.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    if ["bash", "sh", "zsh", "dash", "ksh"].contains(name) { return .bash }
+    if name.hasPrefix("python") { return .python }
+    if name.hasPrefix("ruby") { return .ruby }
+    if name.hasPrefix("node") || name == "nodejs" { return .javascript }
+    return nil
+  }
+
   /// Grammar for a single path, honouring the skip-list. `nil` if skip-listed or unknown.
   static func grammar(forPath path: String) -> GrammarID? {
     let name = (path as NSString).lastPathComponent

--- a/macapp/WorkroomApp/Core/TerminalSessions.swift
+++ b/macapp/WorkroomApp/Core/TerminalSessions.swift
@@ -35,14 +35,18 @@ struct TerminalTab: Identifiable {
     switch content {
     case .terminal(let s): return s.liveTitle ?? s.defaultTitle
     case .diff(let d): return (d.path as NSString).lastPathComponent
+    case .file(let f): return (f.path as NSString).lastPathComponent
     }
   }
 
   /// A content tab still in VS-Code-style preview mode (italic chip, replaced by the next preview);
-  /// always false for terminals.
+  /// always false for terminals. A diff and a file share the target's single preview slot.
   var isPreview: Bool {
-    if case .diff(let d) = content { return d.isPreview }
-    return false
+    switch content {
+    case .diff(let d): return d.isPreview
+    case .file(let f): return f.isPreview
+    case .terminal: return false
+    }
   }
 
   /// Whether a command is actively *working* in this terminal (issue #28) — drives the chip underline
@@ -62,6 +66,11 @@ struct TerminalTab: Identifiable {
   static func diff(_ descriptor: DiffDescriptor) -> TerminalTab {
     TerminalTab(content: .diff(descriptor))
   }
+
+  /// A read-only file content tab from its descriptor (Files inspector section).
+  static func file(_ descriptor: FileDescriptor) -> TerminalTab {
+    TerminalTab(content: .file(descriptor))
+  }
 }
 
 /// A tab's content: a terminal surface, or non-terminal content (issue #66). A closed set — the
@@ -70,6 +79,7 @@ struct TerminalTab: Identifiable {
 enum TabContent {
   case terminal(TerminalState)
   case diff(DiffDescriptor)
+  case file(FileDescriptor)
 }
 
 /// The state a terminal tab owns: its surface plus the live-title/progress the surface reports. Kept
@@ -339,13 +349,74 @@ final class TerminalSessions: ObservableObject {
   }
 
   /// Persist a preview content tab (double-click its chip, or "Keep Open" in its menu). No-op unless
-  /// it's a preview diff tab.
+  /// it's a preview content tab (diff or file).
   func persist(_ tabID: TerminalTab.ID, for target: TerminalTarget) {
-    guard var tab = tabsByTarget[target.id]?[tabID], case .diff(var d) = tab.content, d.isPreview
-    else { return }
-    d.isPreview = false
-    tab.content = .diff(d)
+    guard var tab = tabsByTarget[target.id]?[tabID] else { return }
+    switch tab.content {
+    case .diff(var d) where d.isPreview:
+      d.isPreview = false
+      tab.content = .diff(d)
+    case .file(var f) where f.isPreview:
+      f.isPreview = false
+      tab.content = .file(f)
+    default:
+      return
+    }
     tabsByTarget[target.id]?[tabID] = tab
+  }
+
+  /// Open a file as the target's single PREVIEW content tab (VS-Code semantics), read-only. Shares
+  /// the preview slot with diffs — opening a file preview retargets the lone preview tab whatever it
+  /// showed. Mirrors `openDiffPreview`.
+  @discardableResult
+  func openFilePreview(_ descriptor: FileDescriptor, for target: TerminalTarget) -> TerminalTab.ID {
+    var desc = descriptor
+    desc.isPreview = true
+    if let existing = fileTab(matching: desc, in: target.id) {
+      focus(existing, for: target)
+      return existing
+    }
+    if let previewID = previewTabID(in: target.id), var tab = tabsByTarget[target.id]?[previewID] {
+      tab.content = .file(desc)
+      tabsByTarget[target.id]?[previewID] = tab
+      focus(previewID, for: target)
+      return previewID
+    }
+    let tab = TerminalTab.file(desc)
+    insert(tab, for: target)
+    setFocused(tab.id, for: target.id)
+    reconcileOcclusion(for: target)
+    return tab.id
+  }
+
+  /// Open a file as a PERSISTED content tab (double-click in the Files panel). Promotes an existing
+  /// tab for the same file, else appends a persisted one. Mirrors `openDiffPersistent`.
+  @discardableResult
+  func openFilePersistent(_ descriptor: FileDescriptor, for target: TerminalTarget)
+    -> TerminalTab.ID
+  {
+    var desc = descriptor
+    desc.isPreview = false
+    if let existing = fileTab(matching: desc, in: target.id) {
+      persist(existing, for: target)
+      focus(existing, for: target)
+      return existing
+    }
+    let tab = TerminalTab.file(desc)
+    insert(tab, for: target)
+    setFocused(tab.id, for: target.id)
+    reconcileOcclusion(for: target)
+    return tab.id
+  }
+
+  /// The id of an open file tab showing the same path as `descriptor`, if any.
+  private func fileTab(matching descriptor: FileDescriptor, in target: TerminalTarget.ID)
+    -> TerminalTab.ID?
+  {
+    tabsByTarget[target]?.first { _, tab in
+      if case .file(let f) = tab.content { return f.sameFile(as: descriptor) }
+      return false
+    }?.key
   }
 
   /// Set a diff tab's per-tab layout override (issue #66), from the tab toolbar's unified/side-by-side

--- a/macapp/WorkroomApp/Views/ChangesPanel.swift
+++ b/macapp/WorkroomApp/Views/ChangesPanel.swift
@@ -34,6 +34,16 @@ struct RightInspector: View {
           .environmentObject(store).environmentObject(notifications)),
         AnyView(
           SectionHeader(
+            title: "Files", collapsed: $store.filesSectionCollapsed,
+            shortcut: "⌥⌘F"
+          ) {
+            InspectorHeaderButton(systemImage: "arrow.clockwise", help: "Refresh files") {
+              store.fileTree.reload()
+            }
+          }
+          .environmentObject(store).environmentObject(notifications)),
+        AnyView(
+          SectionHeader(
             title: "Pull Request", collapsed: $store.prSectionCollapsed,
             shortcut: "⌥⌘P"
           ) {
@@ -57,11 +67,16 @@ struct RightInspector: View {
       ],
       bodies: [
         AnyView(ChangesPanel().environmentObject(store).environmentObject(notifications)),
+        AnyView(
+          FilesPanel(model: store.fileTree).environmentObject(store).environmentObject(
+            notifications)
+        ),
         AnyView(PullRequestPanel().environmentObject(store).environmentObject(notifications)),
         AnyView(NotificationsList().environmentObject(store).environmentObject(notifications)),
       ],
       collapsed: [
         store.changesSectionCollapsed,
+        store.filesSectionCollapsed,
         store.prSectionCollapsed,
         store.notificationsSectionCollapsed,
       ],

--- a/macapp/WorkroomApp/Views/CodeTextView.swift
+++ b/macapp/WorkroomApp/Views/CodeTextView.swift
@@ -1,0 +1,295 @@
+import AppKit
+import SwiftUI
+
+/// Read-only, fully selectable code view backed by `NSTextView` — SwiftUI `Text` can only select
+/// within a single view, so arbitrary multi-line selection needs AppKit. Renders the pre-built
+/// syntax-highlighted `NSAttributedString`, paints the find model's match highlights (scrolling the
+/// current into view), and shows a line-number gutter.
+///
+/// The gutter is a SEPARATE scroll view beside the text's scroll view, scroll-synced — *not* an
+/// `NSRulerView` or a subview of the text view, either of which blanks the layer-backed text view's
+/// glyph rendering under SwiftUI's hosting. The two clip views share one vertical offset, so the
+/// numbers stay aligned with their lines.
+struct CodeTextView: NSViewRepresentable {
+  /// The themed, syntax-highlighted content (built by `FileHighlightMapper.nsAttributedString`).
+  let attributed: NSAttributedString
+  /// Bumped by the host whenever `attributed` is replaced (file load, highlight arrival, theme
+  /// change), so the text storage is reset only then — not on every find keystroke.
+  let version: Int
+  let tokens: ThemeTokens
+  @ObservedObject var find: FileFindModel
+  /// Only the focused pane paints find highlights (the find model is shared across panes).
+  let isFocused: Bool
+
+  func makeCoordinator() -> Coordinator { Coordinator() }
+
+  func makeNSView(context: Context) -> NSView {
+    let coordinator = context.coordinator
+    let container = NSView()
+
+    // --- Text scroll view (a bare document view — anything added to it blanks the rendering). ---
+    let textScroll = NSScrollView()
+    textScroll.borderType = .noBorder
+    textScroll.hasVerticalScroller = true
+    textScroll.autohidesScrollers = true
+    textScroll.drawsBackground = true
+    textScroll.backgroundColor = NSColor(tokens.bg)
+
+    let storage = NSTextStorage()
+    let layoutManager = NSLayoutManager()
+    storage.addLayoutManager(layoutManager)
+    let textContainer = NSTextContainer(
+      containerSize: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
+    textContainer.widthTracksTextView = true
+    layoutManager.addTextContainer(textContainer)
+
+    let textView = NSTextView(
+      frame: NSRect(x: 0, y: 0, width: 600, height: 200), textContainer: textContainer)
+    textView.isEditable = false
+    textView.isSelectable = true
+    textView.isRichText = true
+    textView.usesFontPanel = false
+    textView.allowsUndo = false
+    textView.drawsBackground = true
+    textView.backgroundColor = NSColor(tokens.bg)
+    textView.textColor = tokens.nsFg
+    textView.textContainerInset = NSSize(width: 6, height: 8)
+    textView.minSize = NSSize(width: 0, height: 0)
+    textView.maxSize = NSSize(
+      width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+    textView.isVerticallyResizable = true
+    textView.isHorizontallyResizable = false
+    textView.autoresizingMask = [.width]
+    textScroll.documentView = textView
+
+    // --- Gutter scroll view (driven by the text view's scroll; never user-scrolled). ---
+    let gutterScroll = NSScrollView()
+    gutterScroll.borderType = .noBorder
+    gutterScroll.hasVerticalScroller = false
+    gutterScroll.hasHorizontalScroller = false
+    gutterScroll.verticalScrollElasticity = .none
+    gutterScroll.drawsBackground = true
+    gutterScroll.backgroundColor = NSColor(tokens.bg)
+    let gutterView = GutterView()
+    gutterView.textView = textView
+    gutterView.tokens = tokens
+    gutterScroll.documentView = gutterView
+
+    container.addSubview(gutterScroll)
+    container.addSubview(textScroll)
+
+    coordinator.textView = textView
+    coordinator.textScroll = textScroll
+    coordinator.gutterScroll = gutterScroll
+    coordinator.gutterView = gutterView
+
+    // Keep the gutter's vertical offset locked to the text's as it scrolls.
+    textScroll.contentView.postsBoundsChangedNotifications = true
+    coordinator.scrollObserver = NotificationCenter.default.addObserver(
+      forName: NSView.boundsDidChangeNotification, object: textScroll.contentView, queue: .main
+    ) { [weak coordinator] _ in coordinator?.syncGutterScroll() }
+
+    setText(textView, coordinator: coordinator)
+    coordinator.layout(in: container)
+    return container
+  }
+
+  func updateNSView(_ container: NSView, context: Context) {
+    let coordinator = context.coordinator
+    guard let textView = coordinator.textView else { return }
+    textView.backgroundColor = NSColor(tokens.bg)
+    coordinator.textScroll?.backgroundColor = NSColor(tokens.bg)
+    coordinator.gutterScroll?.backgroundColor = NSColor(tokens.bg)
+    coordinator.gutterView?.tokens = tokens
+
+    if coordinator.appliedVersion != version {
+      setText(textView, coordinator: coordinator)
+      coordinator.layout(in: container)
+    }
+    coordinator.applyFind(
+      needle: (isFocused && find.isOpen) ? find.needle : "",
+      current: find.current,
+      highlight: NSColor(tokens.accent))
+  }
+
+  private func setText(_ textView: NSTextView, coordinator: Coordinator) {
+    textView.textStorage?.setAttributedString(attributed)
+    textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+    coordinator.recomputeGutterWidth(lineCount: (attributed.string as NSString).numberOfLines)
+    coordinator.appliedVersion = version
+    coordinator.gutterView?.needsDisplay = true
+  }
+
+  static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+    if let observer = coordinator.scrollObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+  }
+
+  /// Holds the live views + bookkeeping across SwiftUI updates.
+  final class Coordinator {
+    weak var textView: NSTextView?
+    weak var textScroll: NSScrollView?
+    weak var gutterScroll: NSScrollView?
+    weak var gutterView: GutterView?
+    var scrollObserver: NSObjectProtocol?
+    var appliedVersion = -1
+    private(set) var gutterWidth: CGFloat = 44
+    private var highlightedRanges: [NSRange] = []
+    private var lastNeedle = ""
+    private var lastCurrent = -1
+
+    func recomputeGutterWidth(lineCount: Int) {
+      let digits = max(2, String(max(1, lineCount)).count)
+      gutterWidth = ceil(CGFloat(digits) * 7.0) + 22
+    }
+
+    /// Position the gutter (fixed width, left) and the text scroll view (fills the rest), and size
+    /// the gutter's document to the text's height so it scrolls 1:1.
+    func layout(in container: NSView) {
+      let bounds = container.bounds
+      gutterScroll?.frame = NSRect(x: 0, y: 0, width: gutterWidth, height: bounds.height)
+      gutterScroll?.autoresizingMask = [.height]
+      textScroll?.frame = NSRect(
+        x: gutterWidth, y: 0, width: max(0, bounds.width - gutterWidth), height: bounds.height)
+      textScroll?.autoresizingMask = [.width, .height]
+      if let textView, let gutterView {
+        gutterView.frame = NSRect(
+          x: 0, y: 0, width: gutterWidth, height: max(bounds.height, textView.frame.height))
+        gutterView.needsDisplay = true
+      }
+      syncGutterScroll()
+    }
+
+    func syncGutterScroll() {
+      guard let textScroll, let gutterScroll else { return }
+      let y = textScroll.contentView.bounds.origin.y
+      gutterScroll.contentView.scroll(to: NSPoint(x: 0, y: y))
+      gutterScroll.reflectScrolledClipView(gutterScroll.contentView)
+    }
+
+    /// Paint every match's background (the current one stronger) and scroll the current into view.
+    func applyFind(needle: String, current: Int, highlight: NSColor) {
+      guard let textView, let storage = textView.textStorage else { return }
+      if needle == lastNeedle && current == lastCurrent && !needle.isEmpty { return }
+      lastNeedle = needle
+      lastCurrent = current
+
+      for range in highlightedRanges where NSMaxRange(range) <= storage.length {
+        storage.removeAttribute(.backgroundColor, range: range)
+      }
+      highlightedRanges = []
+      guard !needle.isEmpty else { return }
+
+      let text = storage.string as NSString
+      var searchStart = 0
+      var matchIndex = 0
+      var currentRange: NSRange?
+      while searchStart < text.length {
+        let found = text.range(
+          of: needle, options: .caseInsensitive,
+          range: NSRange(location: searchStart, length: text.length - searchStart))
+        if found.location == NSNotFound { break }
+        storage.addAttribute(
+          .backgroundColor,
+          value: highlight.withAlphaComponent(matchIndex == current ? 0.55 : 0.28),
+          range: found)
+        highlightedRanges.append(found)
+        if matchIndex == current { currentRange = found }
+        matchIndex += 1
+        searchStart = found.location + max(found.length, 1)
+      }
+      if let currentRange { textView.scrollRangeToVisible(currentRange) }
+    }
+  }
+}
+
+/// Draws the 1-based line-number column. A normal `NSView` (document view of its own scroll view), so
+/// its `draw` composites reliably; it shares the text view's vertical coordinates, so a number drawn
+/// at a line fragment's y lines up with that line once the two scroll views are offset together.
+final class GutterView: NSView {
+  weak var textView: NSTextView?
+  var tokens: ThemeTokens? { didSet { needsDisplay = true } }
+
+  private static let numberFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
+
+  override var isFlipped: Bool { true }
+  // Scrolling over the gutter should scroll the code, not the (fixed) gutter.
+  override func scrollWheel(with event: NSEvent) {
+    textView?.enclosingScrollView?.scrollWheel(with: event)
+  }
+
+  override func draw(_ dirtyRect: NSRect) {
+    guard
+      let textView,
+      let layoutManager = textView.layoutManager,
+      let container = textView.textContainer,
+      let tokens
+    else { return }
+
+    NSColor(tokens.bg).setFill()
+    dirtyRect.fill()
+    NSColor(tokens.fgMuted).withAlphaComponent(0.15).setFill()
+    NSRect(x: bounds.width - 1, y: dirtyRect.minY, width: 1, height: dirtyRect.height).fill()
+
+    let text = textView.string as NSString
+    let originY = textView.textContainerOrigin.y
+    let attrs: [NSAttributedString.Key: Any] = [
+      .font: Self.numberFont, .foregroundColor: NSColor(tokens.fgMuted),
+    ]
+
+    let containerRect = NSRect(
+      x: 0, y: dirtyRect.minY - originY, width: 100_000, height: dirtyRect.height)
+    let glyphRange = layoutManager.glyphRange(forBoundingRect: containerRect, in: container)
+    let charRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+
+    var lineNumber = countNewlines(in: text, upTo: charRange.location) + 1
+    var index = charRange.location
+    let end = NSMaxRange(charRange)
+    while index < end {
+      let lineRange = text.lineRange(for: NSRange(location: index, length: 0))
+      let glyphIndex = layoutManager.glyphIndexForCharacter(at: lineRange.location)
+      let fragment = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+      let label = "\(lineNumber)" as NSString
+      let size = label.size(withAttributes: attrs)
+      label.draw(
+        at: NSPoint(
+          x: bounds.width - size.width - 7,
+          y: fragment.minY + originY + (fragment.height - size.height) / 2),
+        withAttributes: attrs)
+      lineNumber += 1
+      let next = NSMaxRange(lineRange)
+      if next <= index { break }
+      index = next
+    }
+  }
+
+  private func countNewlines(in text: NSString, upTo limit: Int) -> Int {
+    let end = min(limit, text.length)
+    var count = 0
+    var i = 0
+    while i < end {
+      let r = text.range(of: "\n", options: [], range: NSRange(location: i, length: end - i))
+      if r.location == NSNotFound { break }
+      count += 1
+      i = r.location + 1
+    }
+    return count
+  }
+}
+
+extension NSString {
+  /// Line count = newline count + 1 (non-empty); 1 for the empty string.
+  fileprivate var numberOfLines: Int {
+    guard length > 0 else { return 1 }
+    var count = 1
+    var i = 0
+    while i < length {
+      let r = range(of: "\n", options: [], range: NSRange(location: i, length: length - i))
+      if r.location == NSNotFound { break }
+      count += 1
+      i = r.location + 1
+    }
+    return count
+  }
+}

--- a/macapp/WorkroomApp/Views/DiffViewer.swift
+++ b/macapp/WorkroomApp/Views/DiffViewer.swift
@@ -128,10 +128,16 @@ struct DiffViewer: View {
       return
     }
     // Resolve a grammar from the new path, falling back to the old (rename/delete) path.
-    let grammar =
+    let pathGrammar =
       SyntaxLanguage.grammar(forPath: descriptor.path)
       ?? diff.renamedFrom.flatMap { SyntaxLanguage.grammar(forPath: $0) }
-    guard let grammar else {
+    // An extension-less file may still be detectable via its shebang, which needs the content — so
+    // don't bail before fetching in that case. A file with a known-but-unsupported extension still
+    // short-circuits to plain (no wasted content fetch).
+    let extensionless =
+      (descriptor.path as NSString).pathExtension.isEmpty
+      && (diff.renamedFrom.map { ($0 as NSString).pathExtension.isEmpty } ?? true)
+    guard pathGrammar != nil || extensionless else {
       highlightedLines = [:]
       return
     }
@@ -142,6 +148,12 @@ struct DiffViewer: View {
       : await DiffResolver().fileContent(for: descriptor, in: directory)
     guard !Task.isCancelled else { return }
     guard let content else {
+      highlightedLines = [:]
+      return
+    }
+    // Path detection first, then the shebang on the first line (extension-less scripts).
+    let firstLine = String(content.prefix { $0 != "\n" && $0 != "\r" })
+    guard let grammar = pathGrammar ?? SyntaxLanguage.grammar(forShebang: firstLine) else {
       highlightedLines = [:]
       return
     }

--- a/macapp/WorkroomApp/Views/FileFindBar.swift
+++ b/macapp/WorkroomApp/Views/FileFindBar.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// The find bar overlaid on the focused file viewer (`PlainFileViewer`) while a search is open. Binds
+/// the field to `FileFindModel.needle` (re-searching on change) and reads the match count; prev/next
+/// step matches, Esc/✕ closes. Styled to match the terminal scrollback find bar.
+struct FileFindBar: View {
+  @ObservedObject var model: FileFindModel
+  @FocusState private var fieldFocused: Bool
+
+  var body: some View {
+    if model.isOpen {
+      HStack(spacing: 6) {
+        Image(systemName: "magnifyingglass")
+          .font(.system(size: 12))
+          .foregroundStyle(.secondary)
+
+        TextField(
+          "Find",
+          text: Binding(get: { model.needle }, set: { model.setNeedle($0) })
+        )
+        .textFieldStyle(.plain)
+        .font(.system(size: 12))
+        .frame(width: 170)
+        .focused($fieldFocused)
+        .onSubmit { model.next() }
+
+        Text(model.summary)
+          .font(.system(size: 11))
+          .monospacedDigit()
+          .foregroundStyle(.secondary)
+          .frame(minWidth: 58, alignment: .trailing)
+
+        Divider().frame(height: 14)
+
+        Button {
+          model.previous()
+        } label: {
+          Image(systemName: "chevron.up")
+        }
+        .help("Previous match (⇧⌘G)")
+        .disabled(!model.hasMatches)
+
+        Button {
+          model.next()
+        } label: {
+          Image(systemName: "chevron.down")
+        }
+        .help("Next match (⌘G)")
+        .disabled(!model.hasMatches)
+
+        Button {
+          model.close()
+        } label: {
+          Image(systemName: "xmark")
+        }
+        .help("Close (Esc)")
+      }
+      .buttonStyle(.borderless)
+      .font(.system(size: 12))
+      .padding(.horizontal, 8)
+      .padding(.vertical, 5)
+      .background(
+        RoundedRectangle(cornerRadius: 6, style: .continuous).fill(.regularMaterial)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 6, style: .continuous).strokeBorder(.separator)
+      )
+      .shadow(radius: 8, y: 2)
+      .padding(10)
+      .onAppear { DispatchQueue.main.async { fieldFocused = true } }
+      .onExitCommand { model.close() }
+    }
+  }
+}

--- a/macapp/WorkroomApp/Views/FilesPanel.swift
+++ b/macapp/WorkroomApp/Views/FilesPanel.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+/// The inspector's **Files** section body: the selected repo's working tree as a collapsible,
+/// indented list (it lives inside the inspector's own scroll view, so it flattens the tree to rows
+/// itself rather than hosting a `List`/`OutlineGroup`). A single click on a file opens it read-only
+/// in the main pane (preview), a quick second click persists it, and ⌘-click opens it in the
+/// external editor — mirroring the Changes panel. Directory rows toggle expansion.
+struct FilesPanel: View {
+  @EnvironmentObject var store: AppStore
+  @ObservedObject var model: FileTreeModel
+  private let theme = ThemeService.shared
+
+  var body: some View {
+    Group {
+      switch model.state {
+      case .idle:
+        placeholder("No workroom selected", systemImage: "folder")
+      case .loading:
+        HStack(spacing: 6) {
+          ProgressView().controlSize(.small)
+          Text("Listing files…").font(.callout).foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 6).padding(.horizontal, 8)
+      case .unavailable:
+        placeholder("Not a repository", systemImage: "folder.badge.questionmark")
+      case .loaded:
+        if model.roots.isEmpty {
+          placeholder("No files", systemImage: "folder")
+        } else {
+          fileList
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    // Point the tree at the selected target — but only while this section is expanded, so a selection
+    // (or a collapsed inspector) never lists files you're not looking at. Re-runs on either change;
+    // `activate` no-ops when already on the path, so re-expanding the same target is instant.
+    .task(id: activationKey) {
+      guard !store.filesSectionCollapsed else { return }
+      model.activate(path: store.selectedTarget?.path)
+    }
+  }
+
+  private var activationKey: String {
+    "\(AppStore.targetIDString(for: store.selectedTargetID) ?? "")\u{1F}\(store.filesSectionCollapsed)"
+  }
+
+  private var fileList: some View {
+    let rows = model.rows
+    let capped = Array(rows.prefix(FileTreeModel.renderCap))
+    return VStack(alignment: .leading, spacing: 0) {
+      ForEach(capped, id: \.node.path) { row in
+        FileTreeRowView(model: model, row: row)
+      }
+      if rows.count > capped.count {
+        Text("+\(rows.count - capped.count) more — narrow the tree or open in your editor.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .padding(.vertical, 4).padding(.horizontal, 8)
+      }
+    }
+    .padding(.vertical, 2)
+  }
+
+  private func placeholder(_ text: String, systemImage: String) -> some View {
+    HStack(spacing: 6) {
+      Image(systemName: systemImage).foregroundStyle(.tertiary)
+      Text(text).font(.callout).foregroundStyle(.secondary)
+    }
+    .padding(.vertical, 6).padding(.horizontal, 8)
+  }
+}
+
+/// One row of the Files tree: an indented directory (with a disclosure chevron) or file. Its own
+/// view so hover + the click-timing state stay per-row.
+private struct FileTreeRowView: View {
+  @EnvironmentObject var store: AppStore
+  @ObservedObject var model: FileTreeModel
+  let row: FileTreeRow
+  @State private var hovering = false
+  /// Tracks the previous click time so a quick second click promotes the preview to a persisted tab
+  /// (same manual double-click handling the Changes panel uses).
+  @State private var lastClick: Date?
+  private let theme = ThemeService.shared
+
+  private var node: FileNode { row.node }
+  private var isExpanded: Bool { model.expanded.contains(node.path) }
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Color.clear.frame(width: CGFloat(row.depth) * 13, height: 1)
+      Image(systemName: "chevron.right")
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+        .frame(width: 10)
+        .opacity(node.isDirectory ? 1 : 0)
+      Image(systemName: node.isDirectory ? "folder" : "doc")
+        .font(.system(size: 11))
+        .foregroundStyle(node.isDirectory ? theme.tokens.accent : theme.tokens.fgMuted)
+        .frame(width: 15, alignment: .center)
+      Text(node.name)
+        .font(.callout)
+        .foregroundStyle(.primary)
+        .lineLimit(1).truncationMode(.middle)
+      Spacer(minLength: 0)
+    }
+    .padding(.vertical, 3).padding(.horizontal, 6)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      Rectangle()
+        .fill(hovering ? theme.tokens.rowHover : .clear)
+        .padding(.horizontal, -12)
+    )
+    .contentShape(Rectangle())
+    .onHover { hovering = $0 }
+    .onTapGesture { handleTap() }
+    .help(node.isDirectory ? node.path : "Open \(node.path)")
+    .contextMenu {
+      if !node.isDirectory {
+        Button {
+          store.openFileInEditor(path: node.path)
+        } label: {
+          Label("Open in \(ExternalEditor.remembered?.name ?? "Editor")", systemImage: "doc.text")
+        }
+      }
+    }
+    .accessibilityElement(children: .ignore)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityIdentifier(
+      "files.\(node.isDirectory ? "dir" : "file").\(node.path)"
+    )
+    .accessibilityLabel(
+      node.isDirectory
+        ? "\(node.name), folder, \(isExpanded ? "expanded" : "collapsed")"
+        : "\(node.name), file, open")
+  }
+
+  private func handleTap() {
+    if node.isDirectory {
+      model.toggle(node)
+      lastClick = nil
+      return
+    }
+    if NSEvent.modifierFlags.contains(.command) {
+      store.openFileInEditor(path: node.path)  // ⌘-click → external editor, not the in-app viewer
+      lastClick = nil
+      return
+    }
+    let now = Date()
+    if let last = lastClick, now.timeIntervalSince(last) < 0.35 {
+      store.openFilePersistent(path: node.path)  // quick second click → persist
+      lastClick = nil
+    } else {
+      store.openFilePreview(path: node.path)  // eager: show the read-only preview immediately
+      lastClick = now
+    }
+  }
+}

--- a/macapp/WorkroomApp/Views/MarkdownPreviewView.swift
+++ b/macapp/WorkroomApp/Views/MarkdownPreviewView.swift
@@ -1,0 +1,77 @@
+import AppKit
+import SwiftUI
+
+/// Read-only, selectable rendered-Markdown view (preview mode of the file viewer). Hosts an
+/// `NSTextView` showing `MarkdownRenderer`'s styled `NSAttributedString` — wrapping, no line-number
+/// gutter, with clickable links. Same bare-document-view setup as the source viewer (any added
+/// subview/ruler blanks the layer-backed text view under SwiftUI's hosting).
+struct MarkdownPreviewView: NSViewRepresentable {
+  let attributed: NSAttributedString
+  /// Bumped when `attributed` is replaced (content / theme change) so the text storage resets then.
+  let version: Int
+  let tokens: ThemeTokens
+
+  func makeCoordinator() -> Coordinator { Coordinator() }
+
+  func makeNSView(context: Context) -> NSScrollView {
+    let scrollView = NSScrollView()
+    scrollView.borderType = .noBorder
+    scrollView.hasVerticalScroller = true
+    scrollView.autohidesScrollers = true
+    scrollView.drawsBackground = true
+    scrollView.backgroundColor = NSColor(tokens.bg)
+
+    let storage = NSTextStorage()
+    let layoutManager = NSLayoutManager()
+    storage.addLayoutManager(layoutManager)
+    let container = NSTextContainer(
+      containerSize: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
+    container.widthTracksTextView = true
+    layoutManager.addTextContainer(container)
+
+    let textView = NSTextView(
+      frame: NSRect(x: 0, y: 0, width: 600, height: 200), textContainer: container)
+    textView.isEditable = false
+    textView.isSelectable = true
+    textView.isRichText = true
+    textView.usesFontPanel = false
+    textView.allowsUndo = false
+    textView.isAutomaticLinkDetectionEnabled = false  // links come from the rendered attributes
+    textView.drawsBackground = true
+    textView.backgroundColor = NSColor(tokens.bg)
+    textView.textColor = tokens.nsFg
+    textView.linkTextAttributes = [
+      .foregroundColor: NSColor(tokens.accent),
+      .underlineStyle: NSUnderlineStyle.single.rawValue,
+      .cursor: NSCursor.pointingHand,
+    ]
+    textView.textContainerInset = NSSize(width: 14, height: 12)
+    textView.minSize = NSSize(width: 0, height: 0)
+    textView.maxSize = NSSize(
+      width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+    textView.isVerticallyResizable = true
+    textView.isHorizontallyResizable = false
+    textView.autoresizingMask = [.width]
+
+    scrollView.documentView = textView
+    context.coordinator.textView = textView
+    textView.textStorage?.setAttributedString(attributed)
+    context.coordinator.appliedVersion = version
+    return scrollView
+  }
+
+  func updateNSView(_ scrollView: NSScrollView, context: Context) {
+    guard let textView = context.coordinator.textView else { return }
+    textView.backgroundColor = NSColor(tokens.bg)
+    scrollView.backgroundColor = NSColor(tokens.bg)
+    if context.coordinator.appliedVersion != version {
+      textView.textStorage?.setAttributedString(attributed)
+      context.coordinator.appliedVersion = version
+    }
+  }
+
+  final class Coordinator {
+    weak var textView: NSTextView?
+    var appliedVersion = -1
+  }
+}

--- a/macapp/WorkroomApp/Views/PaneTreeView.swift
+++ b/macapp/WorkroomApp/Views/PaneTreeView.swift
@@ -448,6 +448,19 @@ private struct PaneLeafView: View {
       } else {
         diff
       }
+    case .file(let descriptor):
+      // Read-only file viewer (Files inspector section). Same rounded clip + chip context menu as the
+      // diff leaf, so "Keep Open"/Close behave identically on a previewed file.
+      let file = PlainFileViewer(
+        descriptor: descriptor, directory: target.path, isFocused: focused, find: store.fileFind
+      )
+      .clipShape(
+        RoundedRectangle(cornerRadius: TerminalPanelMetrics.cornerRadius, style: .continuous))
+      if let tab = sessions.tab(tabID, for: target) {
+        file.tabChipContextMenu(tab: tab, target: target, store: store, sessions: sessions)
+      } else {
+        file
+      }
     }
   }
 

--- a/macapp/WorkroomApp/Views/PlainFileViewer.swift
+++ b/macapp/WorkroomApp/Views/PlainFileViewer.swift
@@ -124,7 +124,10 @@ struct PlainFileViewer: View {
   /// or break the viewer.
   private func applyHighlight() async {
     guard state == .text, !content.isEmpty else { return }
-    guard let grammar = SyntaxLanguage.grammar(forPath: descriptor.path) else { return }
+    // Detect by path, then by the shebang on the first line — so an extension-less script
+    // (`#!/usr/bin/env bash`) still highlights. No grammar ⇒ keep the plain (already-shown) string.
+    guard let grammar = SyntaxLanguage.grammar(forPath: descriptor.path, firstLine: lines.first)
+    else { return }
     let source = content
     let spans = await Task.detached(priority: .utility) {
       SyntaxHighlighter.shared.spans(for: source, grammar: grammar)

--- a/macapp/WorkroomApp/Views/PlainFileViewer.swift
+++ b/macapp/WorkroomApp/Views/PlainFileViewer.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+
+/// Read-only viewer for a working-tree file, shown in a content tab when a file is picked in the
+/// inspector's Files section. Reads the file off-main, renders it with line numbers, and applies the
+/// same tree-sitter syntax highlighting the diff viewer uses (degrading to plain on any miss). It is
+/// deliberately read-only — editing stays in the terminal or the external editor (⌘-click a file in
+/// the Files panel). Binary / too-large / unreadable files show a placeholder instead.
+struct PlainFileViewer: View {
+  let descriptor: FileDescriptor
+  /// The workroom directory the repo-relative `descriptor.path` resolves against.
+  let directory: String
+  /// Whether this pane holds focus — only the focused file viewer feeds the find model and shows the
+  /// find bar / match highlights (the model is shared, since only one pane searches at a time).
+  var isFocused: Bool = true
+  /// The shared in-file find state (owned by `AppStore`). The focused viewer feeds it its lines.
+  @ObservedObject var find: FileFindModel
+
+  @State private var state: LoadState = .loading
+  /// The displayed lines (capped — see `lineCap`), the always-available plain fallback.
+  @State private var lines: [String] = []
+  /// The (possibly line-capped) content the highlight task parses; kept so a theme change recolours
+  /// without re-reading the file.
+  @State private var content = ""
+  /// True when the file was longer than `lineCap` and only the head is shown.
+  @State private var truncated = false
+  /// The themed, (optionally) syntax-highlighted content the `NSTextView` renders. Plain immediately
+  /// on load, upgraded when highlighting arrives / the theme changes.
+  @State private var attributed = NSAttributedString()
+  /// Bumped whenever `attributed` is replaced, so `CodeTextView` resets its text storage only then.
+  @State private var version = 0
+  /// Bumped when a file finishes loading, so the highlight task (keyed on it) re-runs against the
+  /// freshly loaded content without re-reading on every theme change.
+  @State private var loadToken = 0
+  private let theme = ThemeService.shared
+
+  /// Files at or over this size aren't loaded (open them in an editor instead). Comfortably above
+  /// the 2 MB syntax-highlight cap, so a big-but-readable file still shows (plain).
+  static let maxBytes = 8 * 1024 * 1024
+  /// Most lines rendered. Bounds the highlight work; the head is shown with a note past it.
+  static let lineCap = 5000
+  /// The code font, shared by the text view and the line-number ruler's alignment.
+  static let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+  enum LoadState: Equatable {
+    case loading
+    case text
+    case empty
+    case binary
+    case tooLarge
+    case failed(String)
+  }
+
+  /// The read outcome, classified purely from the file's bytes (no I/O) so the gating is
+  /// unit-testable. `.text` carries the decoded UTF-8 string.
+  enum Outcome: Equatable {
+    case empty
+    case binary
+    case tooLarge
+    case text(String)
+  }
+
+  var body: some View {
+    content(for: state)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      .background(theme.tokens.bg)
+      // Find bar, pinned top-trailing over the focused pane (the model is shared, so gate on focus).
+      .overlay(alignment: .topTrailing) {
+        if isFocused { FileFindBar(model: find) }
+      }
+      .task(id: descriptor.path) { await load() }
+      .task(id: highlightKey) { await applyHighlight() }
+      // Feed the find model this file's lines when focus arrives (or the file/content changes), so a
+      // search runs against what's actually on screen.
+      .onChange(of: isFocused) { _, focused in if focused { find.setSource(lines) } }
+  }
+
+  /// Identity of the current highlight: file + theme generation + which load it's for. Any change
+  /// cancels the in-flight highlight and starts a fresh, correctly-keyed one.
+  private var highlightKey: String {
+    "\(descriptor.path)\u{1F}\(theme.generation)\u{1F}\(loadToken)"
+  }
+
+  // MARK: Loading
+
+  private func load() async {
+    state = .loading
+    lines = []
+    attributed = NSAttributedString()
+    content = ""
+    truncated = false
+    let absolute = (directory as NSString).appendingPathComponent(descriptor.path)
+    let outcome = await Task.detached(priority: .utility) { () -> Outcome? in
+      guard
+        let data = try? Data(contentsOf: URL(fileURLWithPath: absolute), options: .mappedIfSafe)
+      else { return nil }
+      return PlainFileViewer.classify(data: data)
+    }.value
+    guard !Task.isCancelled else { return }
+    switch outcome {
+    case .none: state = .failed("File unavailable")
+    case .empty: state = .empty
+    case .binary: state = .binary
+    case .tooLarge: state = .tooLarge
+    case .text(let full):
+      var split = PlainFileViewer.splitLines(full)
+      if split.count > Self.lineCap {
+        split = Array(split.prefix(Self.lineCap))
+        truncated = true
+      }
+      lines = split
+      content = split.joined(separator: "\n")
+      // Show the content plain immediately; `applyHighlight` upgrades it with syntax colours.
+      attributed = FileHighlightMapper.nsAttributedString(
+        content: content, spans: [], tokens: theme.tokens, font: Self.font)
+      version &+= 1
+      state = .text
+      loadToken &+= 1
+      if isFocused { find.setSource(split) }  // search this file once it's on screen
+    }
+  }
+
+  /// Build syntax highlighting for the loaded file, off-main and cancellable. Any miss (no grammar,
+  /// parse failure, stale/cancelled) leaves the file rendering plain — highlighting can never block
+  /// or break the viewer.
+  private func applyHighlight() async {
+    guard state == .text, !content.isEmpty else { return }
+    guard let grammar = SyntaxLanguage.grammar(forPath: descriptor.path) else { return }
+    let source = content
+    let spans = await Task.detached(priority: .utility) {
+      SyntaxHighlighter.shared.spans(for: source, grammar: grammar)
+    }.value
+    guard !Task.isCancelled, source == content, !spans.isEmpty else { return }
+    let highlighted = FileHighlightMapper.nsAttributedString(
+      content: source, spans: spans, tokens: theme.tokens, font: Self.font)
+    guard !Task.isCancelled else { return }
+    attributed = highlighted
+    version &+= 1
+  }
+
+  // MARK: Pure helpers (unit-tested)
+
+  /// Classify a file's bytes into a render outcome. Empty → `.empty`; over `byteCap` → `.tooLarge`;
+  /// a NUL byte in the first 8 KB or non-UTF-8 → `.binary`; else the decoded text.
+  static func classify(data: Data, byteCap: Int = maxBytes) -> Outcome {
+    if data.isEmpty { return .empty }
+    if data.count > byteCap { return .tooLarge }
+    if data.prefix(8192).contains(0) { return .binary }
+    guard let string = String(data: data, encoding: .utf8) else { return .binary }
+    return .text(string)
+  }
+
+  /// Split into display lines, dropping the phantom empty line a trailing newline would add (so the
+  /// line count matches an editor's and `FileHighlightMapper`'s).
+  static func splitLines(_ text: String) -> [String] {
+    var lines = text.components(separatedBy: "\n")
+    if lines.count > 1, lines.last == "" { lines.removeLast() }
+    return lines
+  }
+
+  // MARK: Body
+
+  @ViewBuilder private func content(for state: LoadState) -> some View {
+    switch state {
+    case .loading:
+      centered { ProgressView().controlSize(.small) }
+    case .text:
+      fileBody
+    case .empty:
+      message("Empty file", systemImage: "doc", detail: nil)
+    case .binary:
+      message("Binary file", systemImage: "doc.fill", detail: "No preview available.")
+    case .tooLarge:
+      message(
+        "File too large to preview", systemImage: "doc.fill",
+        detail: "Open it in your editor (⌘-click in the Files list).")
+    case .failed(let reason):
+      message("Can't open file", systemImage: "exclamationmark.triangle", detail: reason)
+    }
+  }
+
+  private var fileBody: some View {
+    // An NSTextView (CodeTextView) renders the code: read-only, fully selectable across lines, with a
+    // line-number ruler and find-match highlighting.
+    CodeTextView(
+      attributed: attributed, version: version, tokens: theme.tokens, find: find,
+      isFocused: isFocused
+    )
+    .overlay(alignment: .bottomLeading) {
+      if truncated {
+        Text("File truncated — showing the first \(Self.lineCap) lines.")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 8).padding(.vertical, 4)
+          .background(.regularMaterial, in: Capsule())
+          .padding(8)
+      }
+    }
+  }
+
+  private func message(_ title: String, systemImage: String, detail: String?) -> some View {
+    centered {
+      VStack(spacing: 6) {
+        Image(systemName: systemImage).font(.title2).foregroundStyle(.tertiary)
+        Text(title).font(.callout).foregroundStyle(.secondary)
+        if let detail, !detail.isEmpty {
+          Text(detail).font(.footnote).foregroundStyle(.tertiary)
+            .multilineTextAlignment(.center).lineLimit(3)
+        }
+      }
+      .padding(24)
+    }
+  }
+
+  private func centered<V: View>(@ViewBuilder _ inner: () -> V) -> some View {
+    inner().frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+  }
+}

--- a/macapp/WorkroomApp/Views/PlainFileViewer.swift
+++ b/macapp/WorkroomApp/Views/PlainFileViewer.swift
@@ -31,7 +31,19 @@ struct PlainFileViewer: View {
   /// Bumped when a file finishes loading, so the highlight task (keyed on it) re-runs against the
   /// freshly loaded content without re-reading on every theme change.
   @State private var loadToken = 0
+  /// Source vs. rendered for a Markdown file; ignored for other files (always source). Reset to the
+  /// per-file default on load; a manual toggle persists until the next file opens.
+  @State private var mode: RenderMode = .source
+  /// The rendered-Markdown attributed string for preview mode, and its reset token.
+  @State private var rendered = NSAttributedString()
+  @State private var renderVersion = 0
   private let theme = ThemeService.shared
+
+  enum RenderMode: String, CaseIterable { case source, preview }
+
+  /// Whether this file is Markdown (preview mode is offered only then).
+  private var isMarkdown: Bool { SyntaxLanguage.grammar(forPath: descriptor.path) == .markdown }
+  private var showingPreview: Bool { isMarkdown && mode == .preview }
 
   /// Files at or over this size aren't loaded (open them in an editor instead). Comfortably above
   /// the 2 MB syntax-highlight cap, so a big-but-readable file still shows (plain).
@@ -60,18 +72,49 @@ struct PlainFileViewer: View {
   }
 
   var body: some View {
-    content(for: state)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-      .background(theme.tokens.bg)
-      // Find bar, pinned top-trailing over the focused pane (the model is shared, so gate on focus).
-      .overlay(alignment: .topTrailing) {
-        if isFocused { FileFindBar(model: find) }
+    VStack(spacing: 0) {
+      // Markdown gets a header bar with the Source/Preview switch, so it never overlays the content.
+      if isMarkdown && state == .text { modeToggleBar }
+      content(for: state)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        // Find bar (source mode only — preview has no in-text find), top-trailing over a focused pane.
+        .overlay(alignment: .topTrailing) {
+          if isFocused && !showingPreview { FileFindBar(model: find) }
+        }
+    }
+    .background(theme.tokens.bg)
+    .task(id: descriptor.path) { await load() }
+    .task(id: highlightKey) { await applyHighlight() }
+    // Render Markdown for preview mode (off-main), re-running on content / theme / mode change.
+    .task(id: "\(descriptor.path)\u{1F}\(theme.generation)\u{1F}\(showingPreview)") {
+      await renderMarkdown()
+    }
+    // Feed the find model this file's lines when focus arrives (or the file/content changes), so a
+    // search runs against what's actually on screen.
+    .onChange(of: isFocused) { _, focused in if focused { find.setSource(lines) } }
+  }
+
+  /// The header bar with the Source ⇄ Preview switch (Markdown files only).
+  private var modeToggleBar: some View {
+    HStack(spacing: 0) {
+      Picker("", selection: $mode) {
+        Text("Preview").tag(RenderMode.preview)
+        Text("Source").tag(RenderMode.source)
       }
-      .task(id: descriptor.path) { await load() }
-      .task(id: highlightKey) { await applyHighlight() }
-      // Feed the find model this file's lines when focus arrives (or the file/content changes), so a
-      // search runs against what's actually on screen.
-      .onChange(of: isFocused) { _, focused in if focused { find.setSource(lines) } }
+      .pickerStyle(.segmented)
+      .labelsHidden()
+      .controlSize(.small)
+      .fixedSize()
+      // macOS doesn't show a pointer over controls by default; the switch reads better as a button.
+      .onHover { inside in
+        if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 6)
+    .background(theme.tokens.bg)
+    .overlay(alignment: .bottom) { Divider() }
   }
 
   /// Identity of the current highlight: file + theme generation + which load it's for. Any change
@@ -115,8 +158,22 @@ struct PlainFileViewer: View {
       version &+= 1
       state = .text
       loadToken &+= 1
+      mode = isMarkdown ? .preview : .source  // Markdown opens rendered; others always source
       if isFocused { find.setSource(split) }  // search this file once it's on screen
     }
+  }
+
+  /// Render the Markdown content for preview mode (off-main). Cheap miss when not previewing.
+  private func renderMarkdown() async {
+    guard showingPreview, state == .text, !content.isEmpty else { return }
+    let source = content
+    let tokens = theme.tokens
+    let result = await Task.detached(priority: .utility) {
+      MarkdownRenderer.attributedString(source, tokens: tokens)
+    }.value
+    guard !Task.isCancelled, source == content else { return }
+    rendered = result
+    renderVersion &+= 1
   }
 
   /// Build syntax highlighting for the loaded file, off-main and cancellable. Any miss (no grammar,
@@ -181,21 +238,26 @@ struct PlainFileViewer: View {
     }
   }
 
-  private var fileBody: some View {
-    // An NSTextView (CodeTextView) renders the code: read-only, fully selectable across lines, with a
-    // line-number ruler and find-match highlighting.
-    CodeTextView(
-      attributed: attributed, version: version, tokens: theme.tokens, find: find,
-      isFocused: isFocused
-    )
-    .overlay(alignment: .bottomLeading) {
-      if truncated {
-        Text("File truncated — showing the first \(Self.lineCap) lines.")
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-          .padding(.horizontal, 8).padding(.vertical, 4)
-          .background(.regularMaterial, in: Capsule())
-          .padding(8)
+  @ViewBuilder private var fileBody: some View {
+    if showingPreview {
+      // Rendered Markdown — read-only, selectable, with clickable links.
+      MarkdownPreviewView(attributed: rendered, version: renderVersion, tokens: theme.tokens)
+    } else {
+      // Source: an NSTextView (CodeTextView) — read-only, fully selectable across lines, with a
+      // line-number gutter and find-match highlighting.
+      CodeTextView(
+        attributed: attributed, version: version, tokens: theme.tokens, find: find,
+        isFocused: isFocused
+      )
+      .overlay(alignment: .bottomLeading) {
+        if truncated {
+          Text("File truncated — showing the first \(Self.lineCap) lines.")
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8).padding(.vertical, 4)
+            .background(.regularMaterial, in: Capsule())
+            .padding(8)
+        }
       }
     }
   }

--- a/macapp/WorkroomApp/Views/TerminalTabStrip.swift
+++ b/macapp/WorkroomApp/Views/TerminalTabStrip.swift
@@ -412,6 +412,13 @@ private struct TerminalTabChip: View {
           .foregroundStyle(theme.tokens.fgMuted)
           .accessibilityHidden(true)
       }
+      // A file (content) tab gets a document glyph, same intent as the diff glyph above.
+      if case .file = tab.content {
+        Image(systemName: "doc")
+          .font(.system(size: 9, weight: .semibold))
+          .foregroundStyle(theme.tokens.fgMuted)
+          .accessibilityHidden(true)
+      }
       // Unread activity is marked by a leading accent dot (+ accent title) — a different visual
       // primitive from the selected tab's neutral fill, so the two never read alike.
       if hasActivity {

--- a/macapp/WorkroomApp/WorkroomApp.swift
+++ b/macapp/WorkroomApp/WorkroomApp.swift
@@ -686,6 +686,23 @@ struct WorkroomCommands: Commands {
       )
       .keyboardShortcut("c", modifiers: [.command, .option])
 
+      // View menu: reveal the Files view (the repo file tree) — same open-inspector-and-expand-section
+      // semantics as Changes above.
+      Toggle(
+        "Files",
+        isOn: Binding(
+          get: { showNotifications && !(store?.filesSectionCollapsed ?? true) },
+          set: { on in
+            if on {
+              showNotifications = true
+              store?.filesSectionCollapsed = false
+            } else {
+              store?.filesSectionCollapsed = true
+            }
+          })
+      )
+      .keyboardShortcut("f", modifiers: [.command, .option])
+
       // View menu: reveal the Pull Request view — same open-inspector-and-expand-section semantics
       // as Changes above.
       Toggle(
@@ -780,19 +797,20 @@ struct WorkroomCommands: Commands {
     }
 
     CommandGroup(after: .pasteboard) {
-      // Edit ▸ Find: scrollback search of the focused terminal. ⌘F opens the find bar; ⌘G / ⇧⌘G step
-      // to the next / previous match (wrapping at the ends — see TerminalSearchModel.navigate). All
-      // three are reserved in GhosttySurfaceView.isAppShortcut so the menu key-equivalent wins over
-      // the terminal even while a TUI in an enhanced keyboard mode (Claude/Codex) is running. Find
-      // Next / Previous no-op when no find bar is open. All disabled with no terminal.
+      // Edit ▸ Find: searches the focused pane — the terminal's scrollback for a terminal pane, or the
+      // in-file find for a read-only file viewer. ⌘F opens the find bar; ⌘G / ⇧⌘G step to the next /
+      // previous match (wrapping at the ends). All three are reserved in GhosttySurfaceView.isAppShortcut
+      // so the menu key-equivalent wins over the terminal even while a TUI in an enhanced keyboard mode
+      // (Claude/Codex) is running. Find Next / Previous no-op when no find bar is open. Disabled with no
+      // terminal (a workroom always opens with one; a lone file pane is the only gap).
       Divider()
-      Button("Find…") { store?.startFindInFocusedTerminal() }
+      Button("Find…") { store?.startFindInFocusedPane() }
         .keyboardShortcut("f", modifiers: .command)
         .disabled(hasTerminal != true)
-      Button("Find Next") { store?.navigateFocusedTerminalSearch(forward: true) }
+      Button("Find Next") { store?.navigateFocusedPaneSearch(forward: true) }
         .keyboardShortcut("g", modifiers: .command)
         .disabled(hasTerminal != true)
-      Button("Find Previous") { store?.navigateFocusedTerminalSearch(forward: false) }
+      Button("Find Previous") { store?.navigateFocusedPaneSearch(forward: false) }
         .keyboardShortcut("g", modifiers: [.command, .shift])
         .disabled(hasTerminal != true)
 

--- a/macapp/WorkroomAppTests/FileFindTests.swift
+++ b/macapp/WorkroomAppTests/FileFindTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+
+@testable import Workroom
+
+/// Unit tests for the pure in-file find matcher (`FileFind.matches`) and the observable model's
+/// navigation/highlight logic. The rendering + scroll-to-match live in `PlainFileViewer` and are
+/// covered by manual QA.
+final class FileFindTests: XCTestCase {
+
+  // MARK: FileFind.matches
+
+  func testEmptyNeedleHasNoMatches() {
+    XCTAssertTrue(FileFind.matches(in: ["abc"], needle: "").isEmpty)
+  }
+
+  func testCaseInsensitiveAcrossLinesInDocumentOrder() {
+    let lines = ["Foo bar", "no hit", "food FOO"]
+    let matches = FileFind.matches(in: lines, needle: "foo")
+    XCTAssertEqual(
+      matches,
+      [
+        FileFindMatch(line: 0, range: 0..<3),  // "Foo"
+        FileFindMatch(line: 2, range: 0..<3),  // "food" → "foo"
+        FileFindMatch(line: 2, range: 5..<8),  // "FOO"
+      ])
+  }
+
+  func testMultipleHitsOnOneLineDoNotOverlapOrLoop() {
+    // Overlapping pattern: "aa" in "aaaa" → non-overlapping hits at 0 and 2.
+    let matches = FileFind.matches(in: ["aaaa"], needle: "aa")
+    XCTAssertEqual(
+      matches, [FileFindMatch(line: 0, range: 0..<2), FileFindMatch(line: 0, range: 2..<4)])
+  }
+
+  func testRangesAreCharacterOffsetsNotBytes() {
+    // A multibyte prefix must not shift the offsets off — "é" is one Character.
+    let matches = FileFind.matches(in: ["é foo"], needle: "foo")
+    XCTAssertEqual(matches, [FileFindMatch(line: 0, range: 2..<5)])
+  }
+
+  // MARK: FileFindModel
+
+  @MainActor func testModelComputesSummaryAndNavigatesWithWrap() {
+    let model = FileFindModel()
+    model.setSource(["foo", "foo foo"])
+    model.open()
+    model.setNeedle("foo")
+    XCTAssertEqual(model.matches.count, 3)
+    XCTAssertEqual(model.current, 0)
+    XCTAssertEqual(model.summary, "1/3")
+
+    model.next()
+    XCTAssertEqual(model.current, 1)
+    XCTAssertEqual(model.summary, "2/3")
+
+    model.previous()
+    model.previous()  // wrap from 0 → last
+    XCTAssertEqual(model.current, 2)
+    XCTAssertEqual(model.summary, "3/3")
+  }
+
+  @MainActor func testNoMatchesSummaryAndHighlights() {
+    let model = FileFindModel()
+    model.setSource(["hello"])
+    model.open()
+    model.setNeedle("zzz")
+    XCTAssertFalse(model.hasMatches)
+    XCTAssertEqual(model.summary, "No results")
+    XCTAssertTrue(model.highlights(onLine: 0).isEmpty)
+  }
+
+  @MainActor func testHighlightsMarkCurrentMatch() {
+    let model = FileFindModel()
+    model.setSource(["foo foo"])
+    model.open()
+    model.setNeedle("foo")
+    let line0 = model.highlights(onLine: 0)
+    XCTAssertEqual(line0.count, 2)
+    XCTAssertTrue(line0[0].isCurrent)  // current == 0
+    XCTAssertFalse(line0[1].isCurrent)
+    model.next()
+    XCTAssertFalse(model.highlights(onLine: 0)[0].isCurrent)
+    XCTAssertTrue(model.highlights(onLine: 0)[1].isCurrent)
+  }
+
+  @MainActor func testCloseClearsState() {
+    let model = FileFindModel()
+    model.setSource(["foo"])
+    model.open()
+    model.setNeedle("foo")
+    model.close()
+    XCTAssertFalse(model.isOpen)
+    XCTAssertEqual(model.needle, "")
+    XCTAssertTrue(model.matches.isEmpty)
+    XCTAssertTrue(model.highlights(onLine: 0).isEmpty)
+  }
+
+  @MainActor func testHighlightsEmptyWhenClosed() {
+    let model = FileFindModel()
+    model.setSource(["foo"])
+    model.setNeedle("foo")  // matches exist but bar not open
+    XCTAssertFalse(model.isOpen)
+    XCTAssertTrue(model.highlights(onLine: 0).isEmpty)
+  }
+}

--- a/macapp/WorkroomAppTests/FileTreeTests.swift
+++ b/macapp/WorkroomAppTests/FileTreeTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+
+@testable import Workroom
+
+/// Unit tests for the pure, engine-free core of the Files inspector section (`FileTree.swift`,
+/// `FileHighlightMapper`, and the `PlainFileViewer` read gating). Everything past these needs a live
+/// repo / view and is covered by manual QA.
+final class FileTreeTests: XCTestCase {
+
+  // MARK: FileTreeBuilder.build
+
+  func testBuildNestsAndSortsDirsBeforeFiles() {
+    let roots = FileTreeBuilder.build(from: [
+      "b/y.txt", "b/x.txt", "a.txt", "b/sub/z.txt",
+    ])
+    // Top level: directory "b" before file "a.txt".
+    XCTAssertEqual(roots.map(\.name), ["b", "a.txt"])
+    XCTAssertTrue(roots[0].isDirectory)
+    XCTAssertNotNil(roots[0].children)  // directory has children
+    XCTAssertFalse(roots[1].isDirectory)
+    XCTAssertNil(roots[1].children)  // file leaf
+
+    // Inside "b": directory "sub" first, then files alphabetically.
+    XCTAssertEqual(roots[0].children?.map(\.name), ["sub", "x.txt", "y.txt"])
+    let sub = roots[0].children?.first
+    XCTAssertEqual(sub?.name, "sub")
+    XCTAssertTrue(sub?.isDirectory == true)
+    XCTAssertEqual(sub?.children?.map(\.path), ["b/sub/z.txt"])
+    XCTAssertEqual(sub?.children?.first?.name, "z.txt")
+  }
+
+  func testBuildDedupesIntermediateDirectories() {
+    let roots = FileTreeBuilder.build(from: ["src/a.swift", "src/b.swift"])
+    XCTAssertEqual(roots.count, 1)
+    XCTAssertEqual(roots.first?.name, "src")
+    XCTAssertEqual(roots.first?.children?.map(\.name), ["a.swift", "b.swift"])
+  }
+
+  func testBuildSkipsEmptyAndDotComponentsAndLeadingDotSlash() {
+    let roots = FileTreeBuilder.build(from: ["./a.txt", "", "b//c.txt"])
+    XCTAssertEqual(roots.map(\.name), ["b", "a.txt"])
+    XCTAssertEqual(roots.first { $0.name == "b" }?.children?.map(\.path), ["b/c.txt"])
+  }
+
+  func testBuildEmptyInput() {
+    XCTAssertTrue(FileTreeBuilder.build(from: []).isEmpty)
+  }
+
+  // MARK: FileTreeBuilder.flatten
+
+  func testFlattenRespectsExpansionAndDepth() {
+    let roots = FileTreeBuilder.build(from: ["b/sub/z.txt", "b/x.txt", "a.txt"])
+
+    let collapsed = FileTreeBuilder.flatten(roots, expanded: [])
+    XCTAssertEqual(collapsed.map { "\($0.node.name)@\($0.depth)" }, ["b@0", "a.txt@0"])
+
+    let bOpen = FileTreeBuilder.flatten(roots, expanded: ["b"])
+    XCTAssertEqual(
+      bOpen.map { "\($0.node.name)@\($0.depth)" }, ["b@0", "sub@1", "x.txt@1", "a.txt@0"])
+
+    let allOpen = FileTreeBuilder.flatten(roots, expanded: ["b", "b/sub"])
+    XCTAssertEqual(
+      allOpen.map { "\($0.node.name)@\($0.depth)" },
+      ["b@0", "sub@1", "z.txt@2", "x.txt@1", "a.txt@0"])
+  }
+
+  // MARK: FileListing
+
+  func testListCommands() {
+    XCTAssertEqual(FileListing.command(.git).executable, "git")
+    XCTAssertEqual(
+      FileListing.command(.git).args,
+      ["ls-files", "--cached", "--others", "--exclude-standard", "-z"])
+    XCTAssertEqual(FileListing.command(.jj).executable, "jj")
+    XCTAssertEqual(FileListing.command(.jj).args, ["file", "list"])
+  }
+
+  func testGitParseSplitsOnNulAndPreservesSpaces() {
+    let stdout = "a.txt\u{0}b c.txt\u{0}\u{0}sub/d.txt\u{0}"
+    XCTAssertEqual(FileListing.parse(stdout, vcs: .git), ["a.txt", "b c.txt", "sub/d.txt"])
+  }
+
+  func testJJParseSplitsOnNewlineTrimsCRAndStripsDotSlash() {
+    XCTAssertEqual(
+      FileListing.parse("a.txt\n./sub/d.txt\n\n", vcs: .jj), ["a.txt", "sub/d.txt"])
+    XCTAssertEqual(FileListing.parse("x.txt\r\n", vcs: .jj), ["x.txt"])
+  }
+
+  // MARK: FileTreeModel.list (git → jj fallthrough)
+
+  func testListPrefersGitWhenAvailable() async {
+    let runner = StubRunner(byExecutable: [
+      "git": CommandResult(stdout: "a.txt\u{0}b.txt\u{0}", stderr: "", exitCode: 0, timedOut: false)
+    ])
+    let paths = await FileTreeModel.list(path: "/repo", runner: runner)
+    XCTAssertEqual(paths, ["a.txt", "b.txt"])
+  }
+
+  func testListFallsThroughToJJWhenGitFails() async {
+    let runner = StubRunner(byExecutable: [
+      "git": CommandResult(stdout: "", stderr: "not a repo", exitCode: 128, timedOut: false),
+      "jj": CommandResult(stdout: "x.txt\ny.txt\n", stderr: "", exitCode: 0, timedOut: false),
+    ])
+    let paths = await FileTreeModel.list(path: "/repo", runner: runner)
+    XCTAssertEqual(paths, ["x.txt", "y.txt"])
+  }
+
+  func testListReturnsNilWhenNeitherVCSResponds() async {
+    let runner = StubRunner(byExecutable: [:])  // every command → not-found
+    let paths = await FileTreeModel.list(path: "/repo", runner: runner)
+    XCTAssertNil(paths)
+  }
+
+  // MARK: PlainFileViewer.classify (read gating)
+
+  func testClassifyEmpty() {
+    XCTAssertEqual(PlainFileViewer.classify(data: Data()), .empty)
+  }
+
+  func testClassifyTooLarge() {
+    XCTAssertEqual(PlainFileViewer.classify(data: Data(count: 100), byteCap: 10), .tooLarge)
+  }
+
+  func testClassifyBinaryFromNulByte() {
+    XCTAssertEqual(PlainFileViewer.classify(data: Data([0x41, 0x00, 0x42])), .binary)
+  }
+
+  func testClassifyBinaryFromInvalidUTF8() {
+    // 0xFF/0xFE are not valid UTF-8 and contain no NUL → still binary (decode fails).
+    XCTAssertEqual(PlainFileViewer.classify(data: Data([0xFF, 0xFE, 0x41])), .binary)
+  }
+
+  func testClassifyText() {
+    let data = Data("let x = 1\n".utf8)
+    XCTAssertEqual(PlainFileViewer.classify(data: data), .text("let x = 1\n"))
+  }
+
+  // MARK: PlainFileViewer.splitLines
+
+  func testSplitLinesDropsTrailingNewlinePhantom() {
+    XCTAssertEqual(PlainFileViewer.splitLines("a\nb\n"), ["a", "b"])
+    XCTAssertEqual(PlainFileViewer.splitLines("a\nb"), ["a", "b"])
+    XCTAssertEqual(PlainFileViewer.splitLines("a\n"), ["a"])
+    XCTAssertEqual(PlainFileViewer.splitLines(""), [""])
+  }
+
+  // MARK: FileHighlightMapper (line bucketing)
+
+  @MainActor func testHighlightMapperLineCountAndPlainTextWithoutSpans() {
+    let tokens = ThemeService.shared.tokens
+    let content = "let x = 1\nfoo"
+    let lines = FileHighlightMapper.attributedLines(content: content, spans: [], tokens: tokens)
+    XCTAssertEqual(lines.count, 2)
+    XCTAssertEqual(String(lines[0].characters), "let x = 1")
+    XCTAssertEqual(String(lines[1].characters), "foo")
+  }
+
+  @MainActor func testHighlightMapperDropsTrailingNewlineLine() {
+    let tokens = ThemeService.shared.tokens
+    let lines = FileHighlightMapper.attributedLines(content: "a\n", spans: [], tokens: tokens)
+    XCTAssertEqual(lines.count, 1)
+    XCTAssertEqual(String(lines[0].characters), "a")
+  }
+
+  @MainActor func testHighlightMapperEmptyContent() {
+    let tokens = ThemeService.shared.tokens
+    XCTAssertTrue(
+      FileHighlightMapper.attributedLines(content: "", spans: [], tokens: tokens).isEmpty)
+  }
+}
+
+/// A canned `StatusCommandRunning` for the git→jj fallthrough tests: returns a per-executable result,
+/// or a command-not-found (127) for anything unlisted.
+private struct StubRunner: StatusCommandRunning {
+  let byExecutable: [String: CommandResult]
+
+  func run(_ executable: String, _ args: [String], in directory: String, timeout: TimeInterval)
+    async -> CommandResult
+  {
+    byExecutable[executable]
+      ?? CommandResult(stdout: "", stderr: "", exitCode: 127, timedOut: false)
+  }
+}

--- a/macapp/WorkroomAppTests/InspectorSplitLayoutTests.swift
+++ b/macapp/WorkroomAppTests/InspectorSplitLayoutTests.swift
@@ -31,22 +31,23 @@ final class InspectorSplitLayoutTests: XCTestCase {
   }
 
   func testInstallCreatesOnePanePerSection() {
-    let container = makeContainer(heights: [200, 200, 200])
+    let container = makeContainer(heights: [200, 200, 200, 200])
     XCTAssertEqual(container.panes.count, InspectorSectionKind.allCases.count)
     XCTAssertEqual(container.splitView.arrangedSubviews.count, InspectorSectionKind.allCases.count)
   }
 
   func testUserDividerDragReportsPaneWeights() {
-    let container = makeContainer(heights: [300, 100, 200])
+    let container = makeContainer(heights: [300, 100, 200, 150])
     container.isLikelyUserDrag = { true }
     var reported: [Double]?
     container.onWeightsChanged = { reported = $0 }
     container.splitViewDidResizeSubviews(resizeNotification(container, dividerIndex: 0))
-    XCTAssertEqual(reported, [300, 100, 200], "a divider drag reports the current pane heights")
+    XCTAssertEqual(
+      reported, [300, 100, 200, 150], "a divider drag reports the current pane heights")
   }
 
   func testProgrammaticResizeDoesNotReport() {
-    let container = makeContainer(heights: [300, 100, 200])
+    let container = makeContainer(heights: [300, 100, 200, 150])
     container.isLikelyUserDrag = { true }  // even with a "drag", no divider index → ignored
     var reported: [Double]?
     container.onWeightsChanged = { reported = $0 }
@@ -56,7 +57,7 @@ final class InspectorSplitLayoutTests: XCTestCase {
   }
 
   func testResizeWithoutMouseDownDoesNotReport() {
-    let container = makeContainer(heights: [300, 100, 200])
+    let container = makeContainer(heights: [300, 100, 200, 150])
     container.isLikelyUserDrag = { false }  // animation / programmatic: no mouse button held
     var reported: [Double]?
     container.onWeightsChanged = { reported = $0 }
@@ -65,14 +66,15 @@ final class InspectorSplitLayoutTests: XCTestCase {
   }
 
   func testCollapsedPaneKeepsItsWeightOnDrag() {
-    let container = makeContainer(heights: [300, 34, 200])
-    container.update(workroomKey: "k", collapsed: [false, true, false], weights: [1, 5, 1])
+    let container = makeContainer(heights: [300, 34, 200, 150])
+    container.update(
+      workroomKey: "k", collapsed: [false, true, false, false], weights: [1, 5, 1, 1])
     container.isLikelyUserDrag = { true }
     var reported: [Double]?
     container.onWeightsChanged = { reported = $0 }
     container.splitViewDidResizeSubviews(resizeNotification(container, dividerIndex: 0))
     // Pane 1 is collapsed, so its remembered weight (5) is preserved rather than overwritten with
     // its header height; the expanded panes report their live heights.
-    XCTAssertEqual(reported, [300, 5, 200])
+    XCTAssertEqual(reported, [300, 5, 200, 150])
   }
 }

--- a/macapp/WorkroomAppTests/SyntaxHighlighterTests.swift
+++ b/macapp/WorkroomAppTests/SyntaxHighlighterTests.swift
@@ -153,4 +153,47 @@ final class SyntaxHighlighterTests: XCTestCase {
     XCTAssertEqual(
       SyntaxLanguage.detect(newPath: "data.unknownext", oldPath: "data.json", byteCount: 10), .json)
   }
+
+  // MARK: - Shebang detection (extension-less scripts)
+
+  func testShebangDirectInterpreter() {
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/bin/bash"), .bash)
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/bin/sh"), .bash)
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/zsh"), .bash)
+  }
+
+  func testShebangViaEnvAndVersionSuffix() {
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/env bash"), .bash)
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/env python3"), .python)
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/python3.11"), .python)
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/env ruby"), .ruby)
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/env node"), .javascript)
+  }
+
+  func testShebangEnvSkipsFlags() {
+    // `env -S python3 -u` → the interpreter is python3, not the `-S` flag.
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/env -S python3 -u"), .python)
+  }
+
+  func testShebangToleratesTrailingCR() {
+    // A CRLF first line leaves a trailing `\r` on the interpreter token — must still match.
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/bin/bash\r"), .bash)
+    XCTAssertEqual(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/env python3\r"), .python)
+  }
+
+  func testShebangNonShebangOrUnknownIsNil() {
+    XCTAssertNil(SyntaxLanguage.grammar(forShebang: "not a shebang"))
+    XCTAssertNil(SyntaxLanguage.grammar(forShebang: "#!/usr/bin/env perl"))
+    XCTAssertNil(SyntaxLanguage.grammar(forShebang: "#!"))
+  }
+
+  func testGrammarForPathPrefersExtensionThenShebang() {
+    // A `.sh` extension wins without needing the shebang.
+    XCTAssertEqual(SyntaxLanguage.grammar(forPath: "run.sh", firstLine: nil), .bash)
+    // No extension, but a bash shebang → bash.
+    XCTAssertEqual(
+      SyntaxLanguage.grammar(forPath: "scripts/deploy", firstLine: "#!/usr/bin/env bash"), .bash)
+    // No extension, no shebang → plain.
+    XCTAssertNil(SyntaxLanguage.grammar(forPath: "scripts/deploy", firstLine: "echo hi"))
+  }
 }

--- a/macapp/WorkroomAppTests/WorkroomStatusTests.swift
+++ b/macapp/WorkroomAppTests/WorkroomStatusTests.swift
@@ -262,14 +262,15 @@ final class WorkroomStatusTests: XCTestCase {
     let b = SidebarID.workroom(project: "/p", name: "b")
 
     store.selectedTargetID = a
-    store.updateInspectorSizeWeights([300, 100, 200])
+    store.updateInspectorSizeWeights([300, 100, 200, 150])
 
     store.selectedTargetID = b
     XCTAssertEqual(
-      store.inspectorSizeWeights, [1, 1, 1], "another workroom uses the equal default")
+      store.inspectorSizeWeights, [1, 1, 1, 1], "another workroom uses the equal default")
 
     store.selectedTargetID = a
-    XCTAssertEqual(store.inspectorSizeWeights, [300, 100, 200], "workroom a's drag is restored")
+    XCTAssertEqual(
+      store.inspectorSizeWeights, [300, 100, 200, 150], "workroom a's drag is restored")
   }
 
   // MARK: - PRPresentation (Phase 2 pull-request badge)


### PR DESCRIPTION
@joel this is a change to allow a 4th panel on the right hand tray for file preview/view. It stops short of any editing and keeps it to one window but means you can view the file content without switching to VSCode. I also extended the syntax highlighting detection for the diff rendering to parse the shebangs instead of just file extension.  Details and screenshot below.

## What's new

- **Files section in the inspector tray (the 4th panel).** A VCS-aware file tree of the current workroom — respects ignores (git `ls-files`, jj `file list`), lazily activated so it only lists when the section is shown. Selecting a file opens it in a content tab in the main window.
- **Read-only file viewer.** `NSTextView`-backed so selection works freely across lines, with a line-number gutter and the same tree-sitter syntax highlighting the diff viewer uses (degrading to plain on any miss). In-file find (⌘F) with match highlighting. Binary / too-large / empty files show a placeholder. Deliberately read-only — editing still happens in the terminal or your editor (⌘-click a file in the list to open it externally).
- **Native Markdown preview.** Markdown files open rendered by default, with a header-bar Source ⇄ Preview switch (headings, lists, code blocks, block quotes, rules, inline emphasis/code/links). Source mode falls back to the syntax-highlighted text.
- **Shebang-based language detection.** Extension-less scripts (`#!/usr/bin/env bash`, etc.) now highlight by resolving the interpreter from the first line — wired into **both** the file viewer and the diff viewer.

## How it's built

- **Pure, unit-tested core:** `FileTree` (descriptor/node/builder + git/jj listing), `FileFind`, `FileHighlightMapper`, `MarkdownRenderer`, and shebang resolution in `SyntaxGrammar`.
- **Views:** `FilesPanel`, `PlainFileViewer`, `CodeTextView` (text + a scroll-synced line-number gutter — a separate scroll view rather than an `NSRulerView`, which blanks the layer-backed text view under SwiftUI's hosting), `MarkdownPreviewView`, `FileFindBar`.
- **Wiring:** `AppStore` / `TerminalSessions` / `InspectorPanePolicy` gain a 4th `.files` inspector section and a file tab content type; `DiffViewer` gets the shebang fallback.
- **Tests/gates:** new `FileTreeTests` + `FileFindTests`, shebang cases in `SyntaxHighlighterTests`, and the 4-section updates to `InspectorSplitLayoutTests` / `WorkroomStatusTests`. Full suite green (887 tests), `swift-format --strict` clean.

## Screenshot

<img src="https://raw.githubusercontent.com/iainad/workroom/pr-assets/docs/file-preview.png" alt="The Files inspector section (4th panel) with a syntax-highlighted file open in the main window" width="900">
