### PR TITLE
fix(nightly): exclude floating `nightly` tag from version describe

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,7 +40,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          LATEST="$(git describe --tags --abbrev=0 2>/dev/null || echo v0.0.0)"
+          # --match 'v*' skips the floating `nightly` release tag (retagged to HEAD
+          # each run), which would otherwise win git describe and break parsing.
+          LATEST="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo v0.0.0)"
           RAW="${LATEST#v}"; RAW="${RAW%%+*}"   # strip leading v + any build metadata
           CORE="${RAW%%-*}"                      # MAJOR.MINOR.PATCH
           if [ "$RAW" != "$CORE" ]; then


### PR DESCRIPTION
## Problem

Nightly build [run 29900316173](https://github.com/joelmoss/workroom/actions/runs/29900316173) failed at the "compute version" step:

```
line 9: nightly: unbound variable
```

## Root cause

`gh release create/edit nightly` retags the `nightly` git tag to HEAD every run. So `git describe --tags --abbrev=0` returned `nightly` (the tag sitting at the tip) instead of the latest `v*` release tag. Parsing then set `PATCH=nightly`, and `$((PATCH + 1))` under `set -u` evaluated the bare word `nightly` as a variable → `nightly: unbound variable` → exit 1.

## Fix

Restrict the describe to `v*` semver tags (`--match 'v*'`) so the floating `nightly` tag is ignored. Verified locally: with the tag present, `--match 'v*'` yields `v2.0.0-beta.22` (correct) vs. plain describe yielding `nightly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)