### PR TITLE
perf(ci): skip the Rust VCS-core build when its inputs are unchanged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [master]
 
+# Superseded PR pushes stop burning a macOS runner. Master keeps every run so each commit on the
+# release branch has its own signal.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cli:
     runs-on: ubuntu-latest
@@ -54,21 +60,46 @@ jobs:
       - name: Lint (swift-format --strict)
         run: make app-lint
 
-      # The Rust VCS core (jj-lib via UniFFI) the app links. Cache the heavy jj-lib build + the crate
-      # registry keyed on the lockfile so an unchanged dep set skips recompiling. `make app-vcs` runs
+      # The Rust VCS core (jj-lib via UniFFI) the app links. `make app-vcs` runs
       # vcs/scripts/build-apple.sh to produce the WrVcs package's xcframework + Swift bindings, and
       # MUST run before SPM resolves that local package below. Rust is preinstalled on the runner.
-      - name: Cache Rust build
+      #
+      # Cache the *outputs*, not cargo's state: they only change when vcs/ (or the compiler) does,
+      # which most commits don't touch, so the whole ~4min crate-graph build is skipped outright.
+      # The key mirrors the input hash build-apple.sh stamps, so a restored set is also a no-op for
+      # the app-vcs dep of `make app-test` below. rustc's version is in the key because it's in that
+      # hash — leaving it out would mean a toolchain bump hits the cache, rebuilds anyway, and (the
+      # primary key having hit) never saves the result.
+      - name: Rust toolchain version (cache key input)
+        id: rust
+        run: |
+          # e.g. "rustc 1.96.1 (31fca3adb 2026-06-26)" → "1.96.1-31fca3adb" (cache-key-safe).
+          echo "version=$(rustc --version | awk '{print $2 "-" $3}' | tr -d '()')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache VCS core outputs
+        id: vcs-core
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            vcs/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('vcs/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
+            vcs/swift/WrVcs/Frameworks
+            vcs/swift/WrVcs/Sources/WrVcs/wr_vcs_uniffi.swift
+            vcs/swift/WrVcs/Sources/wr_vcs_uniffiFFI/include
+          key: >-
+            wrvcs-${{ runner.os }}-${{ steps.rust.outputs.version }}-${{
+            hashFiles('vcs/**/*.rs', 'vcs/**/Cargo.toml', 'vcs/Cargo.lock', 'vcs/scripts/build-apple.sh') }}
+
+      # Cold path only (vcs/ changed): keep cargo itself incremental. Swatinem/rust-cache rather than
+      # a hand-rolled actions/cache of ~/.cargo + vcs/target, which restored a target/ whose
+      # fingerprints were always stale — every run recompiled all 257 crates on a cache *hit*, and
+      # the hit meant the useless cache was never re-saved.
+      - name: Cache cargo (cold path)
+        if: steps.vcs-core.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: vcs
 
       - name: Build VCS core (Rust → xcframework + Swift bindings)
+        if: steps.vcs-core.outputs.cache-hit != 'true'
         run: make app-vcs
 
       # The Rust core's own tests (jj-lib reads against real throwaway jj repos, incl. the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,35 @@ jobs:
       - name: Test
         run: go test ./...
 
+  # The Rust VCS core's own tests (jj-lib reads against real throwaway jj repos, incl. the
+  # working-copy snapshot + conflict classification). Its own Linux job rather than a step in `app`:
+  # off the macOS critical path (it was ~3min of it on a cold run), Linux minutes are 10x cheaper,
+  # and it's the only thing testing the core away from Apple targets.
+  vcs-core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # protoc is a build-time dep of jj-lib. The `jj` CLI is what the working_status fixtures shell
+      # out to for repo setup (and the test SKIPS silently without it, so it must be installed) —
+      # apt has no jj package, hence the release tarball. Pinned to the jj-lib version in
+      # vcs/Cargo.toml: bump both together.
+      - name: Install protoc + jj
+        env:
+          JJ_VERSION: 0.43.0
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
+          curl -fsSL "https://github.com/jj-vcs/jj/releases/download/v$JJ_VERSION/jj-v$JJ_VERSION-x86_64-unknown-linux-musl.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin ./jj
+          jj --version
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: vcs
+
+      - name: Test
+        run: cargo test --manifest-path vcs/Cargo.toml
+
   app:
     runs-on: macos-15
     steps:
@@ -102,19 +131,6 @@ jobs:
         if: steps.vcs-core.outputs.cache-hit != 'true'
         run: make app-vcs
 
-      # The Rust core's own tests (jj-lib reads against real throwaway jj repos, incl. the
-      # working-copy snapshot + conflict classification). They ran nowhere in CI before — the Swift
-      # suite only covers what reaches the app through UniFFI. Runs here rather than in its own job
-      # to reuse this one's jj + protobuf install and warm cargo cache.
-      #
-      # Gated on the same cache miss as the build: the key covers every Rust source (tests included),
-      # the manifests and the toolchain, so a hit means these tests already passed on this exact
-      # input — and running them anyway would recompile the whole graph in the test profile (3min),
-      # with no cargo cache restored on that path.
-      - name: Test VCS core (cargo)
-        if: steps.vcs-core.outputs.cache-hit != 'true'
-        run: cargo test --manifest-path vcs/Cargo.toml
-
       # SPM resolves ~15 packages (Sparkle, Sentry, libghostty, the tree-sitter grammars, and
       # swift-syntax pulled transitively) by cloning them from GitHub on every run. Cache the
       # resolved checkouts keyed on project.yml (the sole source of the dependency set — the
@@ -122,16 +138,47 @@ jobs:
       # entirely. The restore-keys fallback reuses an older cache after a dep change so only the
       # delta is fetched.
       - name: Cache SPM packages
+        id: spm
         uses: actions/cache@v4
         with:
           path: macapp/DerivedData/SourcePackages
           key: spm-${{ runner.os }}-${{ hashFiles('macapp/project.yml') }}
           restore-keys: spm-${{ runner.os }}-
 
+      # Compiling the dependency graph — libgit2 (429 tasks), SwiftGitX, the tree-sitter grammars,
+      # Sentry, Sparkle, swift-syntax — is ~60% of the build's work and none of it changes between
+      # runs. Caching the build dir lets xcodebuild's incremental check reuse those objects; only our
+      # own sources rebuild (checkout gives them fresh mtimes, while the restored dep checkouts keep
+      # their original ones, so the dependency objects stay up to date).
+      #
+      # Deliberately NO run-id suffix or restore-keys: the key is exactly what the dep objects depend
+      # on (compiler + the dependency set), so the first run saves and every later run hits without
+      # paying to re-upload ~500MB each time. actions/cache is post-if success(), so a failed build's
+      # dir is never saved.
+      - name: Xcode version (cache key input)
+        id: xcode
+        run: |
+          # e.g. "Xcode 26.0" + "Build version 17A324" → "26.0-17A324".
+          echo "version=$(xcodebuild -version | awk 'NR==1{v=$2} NR==2{b=$NF} END{print v "-" b}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Xcode build dir
+        uses: actions/cache@v4
+        with:
+          path: macapp/DerivedData/Build
+          key: >-
+            xcbuild-${{ runner.os }}-${{ steps.xcode.outputs.version }}-${{
+            hashFiles('macapp/project.yml') }}
+
       # Resolve up front with retries so a transient github.com blip mid-clone can't fail the whole
       # run (it did: swift-syntax clone hit "Couldn't connect to server"). The subsequent app-test
       # build reuses these checkouts via the same -clonedSourcePackagesDirPath, so it won't re-clone.
+      #
+      # Skipped on an exact cache hit: there's nothing to clone, so the whole step (~25s, including an
+      # xcodegen run that `make app-test` does again anyway) is pure overhead. A restore-keys-only
+      # (partial) restore reports no cache-hit, so a dependency change still resolves here, retries
+      # and all.
       - name: Resolve SPM packages (retry on network flake)
+        if: steps.spm.outputs.cache-hit != 'true'
         working-directory: macapp
         run: |
           xcodegen generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,13 @@ jobs:
       # working-copy snapshot + conflict classification). They ran nowhere in CI before — the Swift
       # suite only covers what reaches the app through UniFFI. Runs here rather than in its own job
       # to reuse this one's jj + protobuf install and warm cargo cache.
+      #
+      # Gated on the same cache miss as the build: the key covers every Rust source (tests included),
+      # the manifests and the toolchain, so a hit means these tests already passed on this exact
+      # input — and running them anyway would recompile the whole graph in the test profile (3min),
+      # with no cargo cache restored on that path.
       - name: Test VCS core (cargo)
+        if: steps.vcs-core.outputs.cache-hit != 'true'
         run: cargo test --manifest-path vcs/Cargo.toml
 
       # SPM resolves ~15 packages (Sparkle, Sentry, libghostty, the tree-sitter grammars, and

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,14 @@ APP_XCODEBUILD := xcodebuild -project $(APP_PROJECT) -scheme WorkroomApp -config
 # `make app-test APP_SIGN_FLAGS="CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO DEVELOPMENT_TEAM="`).
 APP_SIGN_FLAGS ?=
 
+# Extra xcodebuild options for app-test. Parallel execution by default: the suite is dominated by a
+# few slow integration classes (Markdown WebView renders, real git/jj repos), so spreading classes
+# across worker processes cuts the run ~40% (48s -> ~29s). Each worker gets its own host-app process
+# but they share one UserDefaults domain, so a test mutating a `Defaults` key another class reads
+# would race — override with `make app-test APP_TEST_FLAGS=` to bisect a suspected parallel-only
+# failure. Test dirs are already UUID-scoped under NSTemporaryDirectory, so those don't collide.
+APP_TEST_FLAGS ?= -parallel-testing-enabled YES
+
 # The Rust VCS core (jj-lib via UniFFI) the app links, built into the local WrVcs SwiftPM package
 # (vcs/swift/WrVcs). Must run before xcodegen so the package's xcframework + generated Swift exist.
 # arm64 by default; release/distribution sets VCS_APPLE_FLAGS=--universal (needs rustup stable >=
@@ -71,7 +79,7 @@ app-build: app-vcs ## Build the app (Debug)
 	cd macapp && xcodegen generate && $(APP_XCODEBUILD) build $(APP_SIGN_FLAGS)
 
 app-test: app-vcs ## Run the app's unit tests
-	cd macapp && xcodegen generate && $(APP_XCODEBUILD) -destination 'platform=macOS' test $(APP_SIGN_FLAGS)
+	cd macapp && xcodegen generate && $(APP_XCODEBUILD) -destination 'platform=macOS' $(APP_TEST_FLAGS) test $(APP_SIGN_FLAGS)
 
 app-uitest: app-vcs ## Run the app's UI tests (XCUITest — needs a real GUI login session, not headless)
 	cd macapp && xcodegen generate && xcodebuild -project $(APP_PROJECT) -scheme WorkroomAppUITests -configuration Debug -derivedDataPath DerivedData -clonedSourcePackagesDirPath DerivedData/SourcePackages -destination 'platform=macOS' test $(APP_SIGN_FLAGS)

--- a/macapp/CLAUDE.md
+++ b/macapp/CLAUDE.md
@@ -12,7 +12,7 @@ root, not `macapp/`):
 ```bash
 make app-run        # canonical local loop: xcodegen → xcodebuild (Debug) → relaunch
 make app-build      # xcodegen → xcodebuild (Debug)
-make app-test       # xcodebuild test (WorkroomAppTests)
+make app-test       # xcodebuild test (WorkroomAppTests) — parallel; APP_TEST_FLAGS= to serialize
 make app-generate   # force-regenerate the (gitignored) .xcodeproj from project.yml
 make app-vcs        # build the Rust VCS core → WrVcs SwiftPM package (auto-run before app builds)
 make app-format     # swift-format, rewrite sources in place

--- a/macapp/CLAUDE.md
+++ b/macapp/CLAUDE.md
@@ -58,6 +58,12 @@ before `app-build`/`app-test`/`app-generate`** (a Makefile prerequisite). Requir
 - arm64 by default; **`make app-release` builds universal** (`VCS_APPLE_FLAGS=--universal`), which
   needs **rustup `stable` ≥ 1.93** + `rustup target add x86_64-apple-darwin aarch64-apple-darwin`
   (Homebrew's rust can't cross-compile; the script preflights this and errors clearly).
+- **Unchanged inputs are a no-op.** The script hashes the Rust sources, manifests/lockfile, itself,
+  `rustc --version` and the arch flavour into `vcs/swift/WrVcs/Frameworks/.build-stamp`, and exits
+  early when that matches and the outputs exist. `WR_VCS_FORCE=1 make app-vcs` rebuilds regardless.
+  CI leans on this: it caches the *outputs* keyed on the same inputs, so a commit that doesn't touch
+  `vcs/` skips the ~4-minute crate-graph build (and `make app-test`'s own `app-vcs` prerequisite
+  stays free).
 
 The xcframework + generated Swift are **gitignored and regenerated**; only `Package.swift` + a
 `shim.c` are tracked. Packaging note: the xcframework is **library-only** (no headers) and the FFI

--- a/vcs/scripts/build-apple.sh
+++ b/vcs/scripts/build-apple.sh
@@ -10,15 +10,50 @@
 # framework dep hits against the other static xcframeworks (e.g. GhosttyKit).
 #   vcs/swift/WrVcs/Frameworks/WrVcsFFI.xcframework   — static lib + FFI headers/modulemap
 #   vcs/swift/WrVcs/Sources/WrVcs/wr_vcs_uniffi.swift — the idiomatic Swift API (module `WrVcs`)
+#
+# Re-running with unchanged inputs is a no-op: the inputs are hashed into a stamp beside the outputs
+# (WR_VCS_FORCE=1 rebuilds regardless). Matters because app-build/app-test/app-release all depend on
+# app-vcs, and CI restores the outputs from cache and must not then recompile the whole crate graph.
 set -euo pipefail
 
 vcs=$(cd "$(dirname "$0")/.." && pwd)   # vcs/
 repo=$(cd "$vcs/.." && pwd)
+self="$vcs/scripts/$(basename "$0")"    # absolute: $0 is relative to the *caller's* cwd, not $vcs
 cd "$vcs"
 
 LIBNAME=libwr_vcs_uniffi.a
 universal=false
 [[ "${1:-}" == "--universal" ]] && universal=true
+
+PKG="$repo/vcs/swift/WrVcs"
+XC="$PKG/Frameworks/WrVcsFFI.xcframework"
+FFI="$PKG/Sources/wr_vcs_uniffiFFI/include"
+GEN="$PKG/Sources/WrVcs"
+# In Frameworks/ so it's covered by the same gitignore entry — and by CI's output cache.
+STAMP="$PKG/Frameworks/.build-stamp"
+
+# Everything that can change the outputs: Rust sources, manifests + lockfile, this script, the
+# compiler, and the arch flavour (a host-arch build must never satisfy a --universal request).
+input_hash() {
+  {
+    # Relative paths (cwd is vcs/) so the hash doesn't move when the repo does — every workroom
+    # copy of the tree would otherwise rebuild from scratch.
+    find . -type f \( -name '*.rs' -o -name 'Cargo.toml' -o -name 'Cargo.lock' \) \
+      -not -path './target/*' -print0 | LC_ALL=C sort -z | xargs -0 shasum -a 256
+    shasum -a 256 < "$self"   # content only: the path itself varies with how we were invoked
+    rustc --version
+    # Tolerate a missing rustup here so the friendlier MSRV error below still gets to fire.
+    if $universal; then rustup run stable rustc --version 2>/dev/null || echo "rustup: none"; fi
+    echo "universal=$universal"
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+WANT=$(input_hash)
+if [ -z "${WR_VCS_FORCE:-}" ] && [ -d "$XC" ] && [ -f "$GEN/wr_vcs_uniffi.swift" ] &&
+  [ -f "$FFI/wr_vcs_uniffiFFI.h" ] && [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$WANT" ]; then
+  echo "up to date: $XC (inputs unchanged; WR_VCS_FORCE=1 to rebuild)"
+  exit 0
+fi
 
 # Build the cdylib+staticlib+bindgen bin (release). For universal, also cross-compile x86_64 and
 # lipo the two staticlibs; otherwise use the host (arm64) staticlib directly.
@@ -51,28 +86,28 @@ rm -rf "$BIND"; mkdir -p "$BIND"
   --library "target/release/libwr_vcs_uniffi.dylib" \
   --language swift --out-dir "$BIND" --no-format
 
-PKG="$repo/vcs/swift/WrVcs"
-
 # Library-ONLY xcframework (no -headers): a headers-bearing static xcframework copies its
 # module.modulemap into the shared Debug/include/, colliding with GhosttyKit's identically-named
 # one ("Multiple commands produce include/module.modulemap"). The importable C module is instead
 # provided by the SPM C target `wr_vcs_uniffiFFI` (headers below), whose modulemap SPM namespaces.
-XC="$PKG/Frameworks/WrVcsFFI.xcframework"
 mkdir -p "$PKG/Frameworks"
+rm -f "$STAMP"   # outputs about to be replaced: don't leave a stamp vouching for a half-built set
 rm -rf "$XC"
 xcodebuild -create-xcframework -library "$LIB" -output "$XC" >/dev/null
 
 # FFI header + modulemap → the wr_vcs_uniffiFFI C target's include dir (module `wr_vcs_uniffiFFI`,
 # which the generated Swift imports).
-FFI="$PKG/Sources/wr_vcs_uniffiFFI/include"
 mkdir -p "$FFI"
 cp "$BIND/wr_vcs_uniffiFFI.h" "$FFI/"
 cp "$BIND/wr_vcs_uniffiFFI.modulemap" "$FFI/module.modulemap"
 
 # Generated Swift API → the WrVcs target (module `WrVcs`).
-GEN="$PKG/Sources/WrVcs"
 mkdir -p "$GEN"
 cp "$BIND/wr_vcs_uniffi.swift" "$GEN/wr_vcs_uniffi.swift"
+
+# Outputs complete — vouch for them. Re-hashed rather than reusing $WANT so a source edit made
+# mid-build doesn't get stamped as built.
+input_hash > "$STAMP"
 
 echo "built: $XC"
 echo "       $GEN/wr_vcs_uniffi.swift"


### PR DESCRIPTION
## Why

The `app` job spent **3m39s of its 8m35s** rebuilding all 257 crates of the jj-lib graph on *every* run — including runs where the cargo cache hit:

```
Cache hit for: cargo-macOS-43e7791...   (339 MB restored)
   Compiling proc-macro2 ... (257 crates)
    Finished `release` profile in 3m 39s
```

The hand-rolled `~/.cargo` + `vcs/target` cache restored a `target/` whose fingerprints were always stale, and because the primary key hit, the post step logged `not saving cache` — so the useless entry stayed frozen until `vcs/Cargo.lock` moved.

## What

- **Cache the build's outputs, not cargo's state.** The xcframework, generated Swift and FFI include are keyed on the rustc version + a hash of the Rust sources, manifests, lockfile and build script. Most commits touch only `macapp/`, so the crate graph isn't compiled at all. rustc's version is in the key deliberately: without it a toolchain bump would hit the cache, rebuild anyway, and never re-save — the same freeze as before.
- **`build-apple.sh` no-ops on unchanged inputs.** It hashes those same inputs into `vcs/swift/WrVcs/Frameworks/.build-stamp` and exits early when the stamp matches and the outputs exist (`WR_VCS_FORCE=1` overrides). Required, because `make app-test` has its own `app-vcs` prerequisite that would otherwise recompile everything the output cache just restored. Local dev gets the same no-op.
- **`Swatinem/rust-cache@v2`** replaces the broken cargo cache on the cold path (`vcs/` actually changed).
- **PR pushes cancel superseded runs**; master keeps per-commit signal.

## Verification

`make app-build` → `BUILD SUCCEEDED` with `app-vcs` reporting `up to date:` — the app links the stamped outputs with zero Rust work.

| case | result |
|---|---|
| cold | 3:39 |
| re-run | **0.13s** (`up to date:`) |
| via `make app-vcs` from repo root | 0.13s (path-independent) |
| new `.rs` added / removed | rebuild |
| output file deleted | rebuild |
| `WR_VCS_FORCE=1` | rebuild |

## Expected CI

First run here is cold on both new keys (~8:30) and seeds them. After that: Swift-only commits **~4:30**; commits touching `vcs/` ~5:30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)