### PR TITLE
fix(macapp): fail the build when the linked Rust VCS core is stale

### DIFF
--- a/macapp/CLAUDE.md
+++ b/macapp/CLAUDE.md
@@ -75,6 +75,13 @@ before `app-build`/`app-test`/`app-generate`** (a Makefile prerequisite). Requir
   CI leans on this: it caches the *outputs* keyed on the same inputs, so a commit that doesn't touch
   `vcs/` skips the ~4-minute crate-graph build (and `make app-test`'s own `app-vcs` prerequisite
   stays free).
+- **Xcode-driven builds are gated, not auto-fixed.** ⌘R/⌘U (and a raw `xcodebuild`) skip the
+  Makefile, so they'd otherwise link the last-built core. A `Rust VCS core up to date` pre-build
+  phase runs `build-apple.sh --check` and **fails the build** with `run 'make app-vcs'` when the
+  stamp doesn't match `vcs/`. It can't rebuild for you: SPM extracts the binaryTarget's xcframework
+  before target build phases run, so a fresh `.a` wouldn't reach that build's link. Silently linking
+  a stale core cost a debugging session once — conflicted files read as `.modified` because the
+  linked core predated a merged per-file-conflict fix.
 
 The xcframework + generated Swift are **gitignored and regenerated**; only `Package.swift` + a
 `shim.c` are tracked. Packaging note: the xcframework is **library-only** (no headers) and the FFI

--- a/macapp/project.yml
+++ b/macapp/project.yml
@@ -312,6 +312,18 @@ targets:
           OTHER_CODE_SIGN_FLAGS: "--timestamp"
           CODE_SIGN_INJECT_BASE_ENTITLEMENTS: NO
     preBuildScripts:
+      # Fail fast when the linked Rust VCS core is older than vcs/. `make app-build`/`app-test`
+      # rebuild it via their app-vcs prerequisite, but ⌘R/⌘U in Xcode (and a raw `xcodebuild`) don't
+      # — so without this gate they link the last-built core and silently exercise a stale engine.
+      # Only a check, never a build: SPM extracts the binaryTarget's xcframework before target build
+      # phases run, so a rebuild here couldn't reach this build's link (see build-apple.sh --check).
+      - name: Rust VCS core up to date
+        basedOnDependencyAnalysis: false
+        script: |
+          if ! out=$("${SRCROOT}/../vcs/scripts/build-apple.sh" --check 2>&1); then
+            echo "error: ${out}"
+            exit 1
+          fi
       - name: swift-format lint
         # Surfaces swift-format violations as build warnings (non-fatal — won't block local
         # builds). `make app-lint` (repo root) runs `--strict` for a hard gate.

--- a/vcs/scripts/build-apple.sh
+++ b/vcs/scripts/build-apple.sh
@@ -3,6 +3,7 @@
 #
 #   build-apple.sh              # arm64 (host) — for local dev on Apple Silicon
 #   build-apple.sh --universal  # arm64 + x86_64 (release/distribution; needs rustup targets)
+#   build-apple.sh --check      # build nothing; exit 1 if the outputs are stale/missing
 #
 # Outputs into the local SwiftPM package vcs/swift/WrVcs (Package.swift is tracked; these two are
 # gitignored + regenerated). Wrapping the static xcframework in an SPM binaryTarget namespaces its
@@ -23,7 +24,11 @@ cd "$vcs"
 
 LIBNAME=libwr_vcs_uniffi.a
 universal=false
-[[ "${1:-}" == "--universal" ]] && universal=true
+check_only=false
+case "${1:-}" in
+  --universal) universal=true ;;
+  --check) check_only=true ;;
+esac
 
 PKG="$repo/vcs/swift/WrVcs"
 XC="$PKG/Frameworks/WrVcsFFI.xcframework"
@@ -49,8 +54,26 @@ input_hash() {
 }
 
 WANT=$(input_hash)
-if [ -z "${WR_VCS_FORCE:-}" ] && [ -d "$XC" ] && [ -f "$GEN/wr_vcs_uniffi.swift" ] &&
-  [ -f "$FFI/wr_vcs_uniffiFFI.h" ] && [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$WANT" ]; then
+up_to_date=false
+if [ -d "$XC" ] && [ -f "$GEN/wr_vcs_uniffi.swift" ] && [ -f "$FFI/wr_vcs_uniffiFFI.h" ] &&
+  [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$WANT" ]; then
+  up_to_date=true
+fi
+
+# --check reports, never builds. It's the Xcode pre-build gate (see macapp/project.yml): an
+# Xcode-driven build (⌘R/⌘U) or a raw `xcodebuild` has no `app-vcs` prerequisite, so it would
+# happily link whatever core was built last — silently testing a stale engine (that cost a real
+# debugging session: conflicted files read as `.modified` after a merge brought in a jj fix).
+# Deliberately does NOT rebuild: SPM extracts a binaryTarget's xcframework before target build
+# phases run, so replacing the .a here wouldn't reach *this* build's link anyway — better to stop
+# with an actionable message than to look fixed while still linking the old core.
+if $check_only; then
+  $up_to_date && { echo "up to date: $XC"; exit 0; }
+  echo "stale: the Rust VCS core doesn't match vcs/ — run 'make app-vcs'" >&2
+  exit 1
+fi
+
+if [ -z "${WR_VCS_FORCE:-}" ] && $up_to_date; then
   echo "up to date: $XC (inputs unchanged; WR_VCS_FORCE=1 to rebuild)"
   exit 0
 fi


### PR DESCRIPTION
`make app-build`/`app-test` rebuild the Rust VCS core through their `app-vcs` prerequisite, but ⌘R/⌘U in Xcode and a raw `xcodebuild` don't — they link whatever core was built last, silently.

That cost a real debugging session: two jj conflict tests failed locally and passed in CI, because the locally linked core predated a merged per-file-conflict fix (`7354301d`), so conflicted files came back as `.modified`. Nothing anywhere said the engine was old.

A `Rust VCS core up to date` pre-build phase now runs `vcs/scripts/build-apple.sh --check`, which compares the same input hash the build stamps and fails with `run 'make app-vcs'` when they differ. Free on the common path — a hash of `vcs/`, no cargo.

**Checks rather than rebuilds on purpose.** SPM extracts a binaryTarget's xcframework *before* target build phases run, so a fresh `.a` written from the phase couldn't reach that build's link — it would look fixed while still linking the old core.

### Verification

Both paths driven through a real `xcodebuild`, not just the script:

| state | result |
|---|---|
| core fresh | `** BUILD SUCCEEDED`, gate silent |
| `vcs/` touched | exit 65, `error: stale: the Rust VCS core doesn't match vcs/ — run 'make app-vcs'` |

Confirmed the phase executes (`PhaseScriptExecution Rust\ VCS\ core\ up\ to\ date`), and that `--check` is content-hashed — `touch` alone doesn't trip it. `make app-lint` clean; `bash -n` clean; `project.yml` parses.

Note: this commit edits `build-apple.sh`, whose own content is a hash input, so CI's VCS-core output cache misses once and this run takes the cold path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)